### PR TITLE
Clarify script invocation with sh

### DIFF
--- a/install_modules.sh
+++ b/install_modules.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./install_modules.sh [--debug[=FILE]] [-h] [module1 module2 ...]
+# Usage: sh install_modules.sh [--debug[=FILE]] [-h] [module1 module2 ...]
 #
 # Description:
 #   Runs each module's setup script in order. If no modules are given on the
@@ -52,7 +52,7 @@ export PROJECT_ROOT
 
 usage() {
   cat <<EOF
-  Usage: $(basename "$0") [--debug[=FILE]] [-h] [module1 module2 ...]
+  Usage: sh $(basename "$0") [--debug[=FILE]] [-h] [module1 module2 ...]
 
   Description:
     Install one or more module setups (or all enabled modules by default)

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./setup.sh [--debug[=FILE]] [-h]
+# Usage: sh setup.sh [--debug[=FILE]] [-h]
 #
 # Description:
 #   Sets hostname, networking (ifconfig/route), /etc/resolv.conf, hardens SSH,
@@ -40,7 +40,7 @@ export PROJECT_ROOT
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Set up system hostname, networking, and base packages

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the base-system setup: hostname/ifconfig/route,
@@ -45,7 +45,7 @@ export PROJECT_ROOT
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Validate OpenBSD base system configuration and network setup

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./setup.sh [--debug[=FILE]] [-h]
+# Usage: sh setup.sh [--debug[=FILE]] [-h]
 #
 # Description:
 #   Copies the deploy key into /root/.ssh, hard-locks its permissions, adds
@@ -42,7 +42,7 @@ export PROJECT_ROOT
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Configure GitHub deploy key and initialize bare repo

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the GitHub sync setup: verifies that the SSH
@@ -46,7 +46,7 @@ export PROJECT_ROOT
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Verify GitHub deploy key and repo bootstrap for Git sync

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # test_obsidian_git_client.sh – Verify client-side Obsidian Git sync (with optional logging)
-# Usage: ./test_obsidian_git_client.sh [--log[=FILE]] [-h]
+# Usage: sh test_obsidian_git_client.sh [--log[=FILE]] [-h]
 #
 
 set -ex  # -e: exit on error; -x: trace commands
@@ -36,7 +36,7 @@ LOGFILE=""
 #
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--log[=FILE]] [-h]
+Usage: sh $(basename "$0") [--log[=FILE]] [-h]
 
   --log, -l       Capture stdout, stderr & xtrace into:
                    ${PROJECT_ROOT}/logs/$(basename "$0" .sh)-TIMESTAMP.log

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -4,7 +4,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./setup.sh [--debug[=FILE]] [-h]
+# Usage: sh setup.sh [--debug[=FILE]] [-h]
 #
 # Description:
 #   Sets up Git/Obsidian users and group, hardens SSH, writes doas rules,
@@ -40,7 +40,7 @@ export PROJECT_ROOT
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Set up Git user, vault repository, and post-receive hook

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the Obsidian Git host setup: users/groups,
@@ -45,7 +45,7 @@ export PROJECT_ROOT
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Validate Obsidian vault sync setup on the Git host

--- a/test_all.sh
+++ b/test_all.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: ./test_all.sh [--log[=FILE]] [--debug] [-h] [module1 module2 ...]
+# Usage: sh test_all.sh [--log[=FILE]] [--debug] [-h] [module1 module2 ...]
 #
 # Description:
 #   Executes each selected module's test.sh and reports a pass/fail summary.
@@ -53,7 +53,7 @@ export PROJECT_ROOT MODULE_DIR
 
 show_help() {
   cat <<-EOF
-  Usage: $(basename "$0") [options]
+  Usage: sh $(basename "$0") [options]
 
   Description:
     Run test scripts for one or more modules (or all enabled modules by default)


### PR DESCRIPTION
## Summary
- document that scripts expect `sh` invocation
- update help text across setup and test scripts accordingly

## Testing
- `sh test_all.sh` *(fails: deploy key present, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bf5cfb09c832796977e983e755d85