### PR TITLE
Simplify logging initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Use `--debug[=FILE]` to enable verbose tracing and optionally direct output to a
 
 Use `--log[=FILE]` to force a log file to be written even when all tests pass (only supported by test scripts).
 
+### Simplified logging helpers
+
+Scripts source `logs/logging.sh` and invoke one of these convenience functions:
+
+```sh
+. "$PROJECT_ROOT/logs/logging.sh"
+start_logging "$0" "$@"            # for test scripts
+# or
+start_logging_if_debug "setup-my-module" "$@"  # for setup scripts
+```
+
+`start_logging` automatically sets up logging, enables debug tracing when
+`--debug` is provided, and registers `finalize_logging` on exit.
+
 ---
 
 ## 🛡️ Security Notes

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -70,14 +70,8 @@ done
 
 # shellcheck source=logs/logging.sh
 . "$PROJECT_ROOT/logs/logging.sh"
-parse_logging_flags "$@"
-eval "set -- $REMAINING_ARGS"
-
 module_name="$(basename "$SCRIPT_DIR")"
-if [ "$DEBUG_MODE" -eq 1 ]; then
-  set -vx  # enable xtrace
-  init_logging "setup-$module_name"
-fi
+start_logging_if_debug "setup-$module_name" "$@"
 
 ##############################################################################
 # 3) Load secrets

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -68,18 +68,7 @@ done
 ##############################################################################
 
 . "$PROJECT_ROOT/logs/logging.sh"
-parse_logging_flags "$@"
-eval "set -- $REMAINING_ARGS"
-
-# If running standalone with log/debug requested, include module name in logfile
-if { [ "$FORCE_LOG" -eq 1 ] || [ "$DEBUG_MODE" -eq 1 ]; } && [ -z "$LOGGING_INITIALIZED" ]; then
-  module_name=$(basename "$SCRIPT_DIR")
-  init_logging "${module_name}-$(basename "$0")"
-else
-  init_logging "$0"
-fi
-trap finalize_logging EXIT
-[ "$DEBUG_MODE" -eq 1 ] && set -vx
+start_logging "$SCRIPT_PATH" "$@"
 
 ##############################################################################
 # 3) Load secrets

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -71,14 +71,8 @@ done
 
 # shellcheck source=logs/logging.sh
 . "$PROJECT_ROOT/logs/logging.sh"
-parse_logging_flags "$@"
-eval "set -- $REMAINING_ARGS"
-
 module_name="$(basename "$SCRIPT_DIR")"
-if [ "$DEBUG_MODE" -eq 1 ]; then
-  set -vx  # enable xtrace
-  init_logging "setup-$module_name"
-fi
+start_logging_if_debug "setup-$module_name" "$@"
 
 ##############################################################################
 # 3) Inputs (secrets & constants) + validation

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -70,18 +70,7 @@ done
 
 # shellcheck source=logs/logging.sh
 . "$PROJECT_ROOT/logs/logging.sh"
-parse_logging_flags "$@"
-eval "set -- $REMAINING_ARGS"
-
-# If running standalone with log/debug requested, include module name in logfile
-if { [ "$FORCE_LOG" -eq 1 ] || [ "$DEBUG_MODE" -eq 1 ]; } && [ -z "$LOGGING_INITIALIZED" ]; then
-  module_name=$(basename "$SCRIPT_DIR")
-  init_logging "${module_name}-$(basename "$0")"
-else
-  init_logging "$0"
-fi
-trap finalize_logging EXIT
-[ "$DEBUG_MODE" -eq 1 ] && set -vx
+start_logging "$SCRIPT_PATH" "$@"
 
 
 ##############################################################################

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -70,14 +70,8 @@ done
 
 # shellcheck source=logs/logging.sh
 . "$PROJECT_ROOT/logs/logging.sh"
-parse_logging_flags "$@"
-eval "set -- $REMAINING_ARGS"
-
 module_name="$(basename "$SCRIPT_DIR")"
-if [ "$DEBUG_MODE" -eq 1 ]; then
-  set -vx  # enable xtrace
-  init_logging "setup-$module_name"
-fi
+start_logging_if_debug "setup-$module_name" "$@"
 
 ##############################################################################
 # 3) Secrets & required vars

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -68,17 +68,7 @@ done
 ##############################################################################
 
 . "$PROJECT_ROOT/logs/logging.sh"
-parse_logging_flags "$@"
-eval "set -- $REMAINING_ARGS"
-
-if { [ "$FORCE_LOG" -eq 1 ] || [ "$DEBUG_MODE" -eq 1 ]; } && [ -z "$LOGGING_INITIALIZED" ]; then
-  module_name=$(basename "$SCRIPT_DIR")
-  init_logging "${module_name}-$(basename "$0")"
-else
-  init_logging "$0"
-fi
-trap finalize_logging EXIT
-[ "$DEBUG_MODE" -eq 1 ] && set -vx
+start_logging "$SCRIPT_PATH" "$@"
 
 ##############################################################################
 # 3) Secrets & required vars


### PR DESCRIPTION
## Summary
- add `start_logging` and `start_logging_if_debug` helpers
- document simpler logging invocation in README
- update module scripts to use the new helpers

## Testing
- `sh test_all.sh` *(fails: Module tests fail in container)*

------
https://chatgpt.com/codex/tasks/task_e_688bf2650d98832799e4df0371605c58