### PR TITLE
Remove debug echoes from base-system test

### DIFF
--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -80,9 +80,6 @@ start_logging "$SCRIPT_PATH" "$@"
 # 4) Test helpers
 ##############################################################################
 
-echo "stdout: hello world"
-echo "stderr: uh oh" >&2
-
 run_test() {
   desc="$2"
   output="$(eval "$1" 2>&1)"


### PR DESCRIPTION
## Summary
- tidy `modules/base-system/test.sh` by removing leftover "hello world"/"uh oh" debug lines
- keep `run_test` helper to report TAP-style results for the suite

## Testing
- `sh modules/base-system/test.sh --log` *(fails: hostname.em0 exists, correct 'inet IP MASK' line, correct default route line, resolv.conf contains DNS1, resolv.conf contains DNS2, resolv.conf mode is 644, interface up with correct IP, default route via 192.0.2.1, sshd_config disallows root login, sshd_config disallows password auth, sshd service is running, root .profile sets HISTFILE, root .profile sets HISTSIZE, root .profile sets HISTCONTROL)*

------
https://chatgpt.com/codex/tasks/task_e_688c08624f648327b287c3ac5e920e16