### PR TITLE
obsidian-git-host: correct shebang in setup script

### DIFF
--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh #
+#!/bin/sh
 # modules/obsidian-git-host/setup.sh — Git-backed Obsidian vault setup
 # Author: deadhedd
 # Version: 1.0.0


### PR DESCRIPTION
## Summary
- fix obsidian-git-host setup.sh shebang to use standard `/bin/sh`

## Testing
- `sh test_all.sh obsidian-git-host` *(fails: Module 'obsidian-git-host' FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_688c0885637c8327b963d30ca40aa9b6