### PR TITLE
docs: add module readmes

### DIFF
--- a/modules/base-system/README.md
+++ b/modules/base-system/README.md
@@ -1,0 +1,28 @@
+# base-system
+
+## Purpose
+Configures hostname, networking, SSH hardening and root shell history on a fresh OpenBSD server.
+
+## Prerequisites
+- Run as root on OpenBSD 7.4+
+- `config/secrets.env` populated and readable by the scripts
+
+## Key variables
+| Variable | Description |
+| --- | --- |
+| `INTERFACE` | Network interface to configure (e.g. `em0`) |
+| `GIT_SERVER` | Server IP address |
+| `NETMASK` | Network mask |
+| `GATEWAY` | Default gateway |
+| `DNS1`, `DNS2` | Resolver addresses |
+
+## Setup
+```sh
+cd modules/base-system
+sh setup.sh [--debug]
+```
+
+## Testing
+```sh
+sh test.sh [--debug]
+```

--- a/modules/github/README.md
+++ b/modules/github/README.md
@@ -1,0 +1,26 @@
+# github
+
+## Purpose
+Installs a deploy key for GitHub and clones a remote repository for use with Obsidian.
+
+## Prerequisites
+- Run as root on OpenBSD 7.4+
+- `config/secrets.env` with required values
+- `config/deploy_key` containing the private deploy key
+
+## Key variables
+| Variable | Description |
+| --- | --- |
+| `LOCAL_DIR` | Destination path for the local clone |
+| `GITHUB_REPO` | GitHub repository URL |
+
+## Setup
+```sh
+cd modules/github
+sh setup.sh [--debug]
+```
+
+## Testing
+```sh
+sh test.sh [--debug]
+```

--- a/modules/obsidian-git-client/README.md
+++ b/modules/obsidian-git-client/README.md
@@ -1,0 +1,28 @@
+# obsidian-git-client
+
+## Purpose
+Checks that a workstation can pull and push an Obsidian vault over SSH.
+
+## Prerequisites
+- Client with Git, ssh-agent and access to the remote server
+- `config/secrets.env` filled with connection details
+- Vault repository cloned locally at `$HOME/$VAULT`
+
+## Key variables
+| Variable | Description |
+| --- | --- |
+| `GIT_USER` | Remote git service account |
+| `OBS_USER` | Remote Obsidian account |
+| `VAULT` | Vault/repository name |
+| `SERVER` | Hostname or IP of the git server |
+
+## Setup
+1. Copy `config/secrets.env.example` to `config/secrets.env` and edit the values.
+2. Start `ssh-agent` and add your private key.
+3. Clone the remote vault to `$HOME/$VAULT`.
+
+## Testing
+```sh
+cd modules/obsidian-git-client
+sh test.sh [--log[=FILE]]
+```

--- a/modules/obsidian-git-host/README.md
+++ b/modules/obsidian-git-host/README.md
@@ -1,0 +1,28 @@
+# obsidian-git-host
+
+## Purpose
+Creates users, SSH rules and a shared bare Git repository so multiple accounts can sync an Obsidian vault.
+
+## Prerequisites
+- Run as root on OpenBSD 7.4+
+- `config/secrets.env` populated
+- Network access to the Git server
+
+## Key variables
+| Variable | Description |
+| --- | --- |
+| `OBS_USER` | Local Obsidian user |
+| `GIT_USER` | Service account used for pushes |
+| `VAULT` | Vault name used for repository paths |
+| `GIT_SERVER` | Hostname or IP for known_hosts entry |
+
+## Setup
+```sh
+cd modules/obsidian-git-host
+sh setup.sh [--debug]
+```
+
+## Testing
+```sh
+sh test.sh [--debug]
+```


### PR DESCRIPTION
## Summary
- add concise README files for base-system, github, obsidian-git-host and obsidian-git-client modules
- document prerequisites, configuration variables and how to run setup/test scripts

## Testing
- `sh modules/base-system/test.sh` *(fails: netstat missing, sshd not configured)*
- `sh modules/github/test.sh` *(fails: deploy key and repo not present)*
- `sh modules/obsidian-git-host/test.sh` *(fails: environment not provisioned)*
- `sh modules/obsidian-git-client/test.sh` *(fails: logging helper missing)*

------
https://chatgpt.com/codex/tasks/task_e_688c0b4e0db48327ba533cf3d1066d63