### PR TITLE
Remove verbose tracing from test scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file following [K
 
 ---
 
+## Unreleased
+
+### Logging and Debugging
+
+* Dropped `set -v` from test scripts, now using `set -x` while setup scripts
+  continue to leverage `set -vx` for expanded command logging.
+
 ## v1.0 – Initial Stable Release (2025-07-26)
 
 ### Setup and Tests

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -22,9 +22,9 @@
 #   FD 3 is reserved for real stdout so debug messages can bypass redirection.
 #
 # Security note:
-#   Enabling the --debug flag will log all executed commands *and their expanded
-#   values* (via `set -vx`), including any exported secrets or credentials. Use
-#   caution when sharing or retaining debug logs.
+#   Enabling the --debug flag will log all executed commands. Setup scripts also
+#   log their expanded values (via `set -vx`), which may include exported secrets
+#   or credentials. Use caution when sharing or retaining debug logs.
 #
 # See also:
 #   - config/load-secrets.sh
@@ -99,7 +99,7 @@ start_logging() {
     init_logging "$context"
   fi
   trap finalize_logging EXIT
-  [ "$DEBUG_MODE" -eq 1 ] && set -vx
+  [ "$DEBUG_MODE" -eq 1 ] && set -x
 }
 
 # start_logging_if_debug <context> [args...]

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -18,9 +18,10 @@
 #   has already been completed.
 #
 # Security note:
-#   Enabling the --debug flag will log all executed commands *and their expanded
-#   values* (via `set -vx`), including any exported secrets or credentials.
-#   Use caution when sharing or retaining debug logs.
+#   Enabling the --debug flag will log all executed commands (via `set -x`).
+#   Setup scripts still log expanded values via `set -vx`, which may include
+#   exported secrets or credentials. Use caution when sharing or retaining
+#   debug logs.
 #
 # See also:
 #   - modules/base-system/setup.sh

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -19,9 +19,10 @@
 #   been completed.
 #
 # Security note:
-#   Enabling the --debug flag will log all executed commands *and their expanded
-#   values* (via `set -vx`), including any exported secrets or credentials.
-#   Use caution when sharing or retaining debug logs.
+#   Enabling the --debug flag will log all executed commands (via `set -x`).
+#   Setup scripts still log expanded values via `set -vx`, which may include
+#   exported secrets or credentials. Use caution when sharing or retaining
+#   debug logs.
 #
 # See also:
 #   - modules/github/setup.sh

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -14,9 +14,10 @@
 #   a test commit succeeds.
 #
 # Security note:
-#   Enabling the --debug flag will log all executed commands and their expanded
-#   values (via `set -vx`), including any exported secrets or credentials. Use
-#   caution when sharing or retaining debug logs.
+#   Enabling the --debug flag will log all executed commands (via `set -x`).
+#   Setup scripts still log expanded values via `set -vx`, which may include
+#   exported secrets or credentials. Use caution when sharing or retaining
+#   debug logs.
 
 ##############################################################################
 # 0) Resolve paths

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -18,9 +18,10 @@
 #   checks will fail unless it (or equivalent steps) has been completed.
 #
 # Security note:
-#   Enabling the --debug flag will log all executed commands *and their expanded
-#   values* (via `set -vx`), including any exported secrets or credentials.
-#   Use caution when sharing or retaining debug logs.
+#   Enabling the --debug flag will log all executed commands (via `set -x`).
+#   Setup scripts still log expanded values via `set -vx`, which may expose
+#   exported secrets or credentials. Use caution when sharing or retaining
+#   debug logs.
 #
 # See also:
 #   - modules/obsidian-git-host/setup.sh

--- a/test_all.sh
+++ b/test_all.sh
@@ -17,9 +17,9 @@
 #   Forwards --debug or --log to individual module tests when supplied.
 #
 # Security note:
-#   Enabling the --debug flag will log all executed commands *and their expanded
-#   values* (via `set -vx`), including any exported secrets or credentials.
-#   Use caution when sharing or retaining debug logs.
+#   Enabling the --debug flag will log all executed commands *without* their
+#   expanded values (test scripts use `set -x`). Setup scripts still capture
+#   expansions via `set -vx`. Use caution when sharing or retaining debug logs.
 #
 # See also:
 #   - modules/ (each module contains setup.sh and test.sh)


### PR DESCRIPTION
## Summary
- drop `set -v` usage from test logging while retaining it in setup helpers
- update test scripts to mention `set -x` debugging
- document change in changelog

## Testing
- `sh test_all.sh` *(fails: user 'obsidian' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688c252f7f648327ac25f2bdb95f6b0a