### PR TITLE
Allow custom log file with debug flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file following [K
 
 * Dropped `set -v` from test scripts, now using `set -x` while setup scripts
   continue to leverage `set -vx` for expanded command logging.
+* Added support for `--debug=FILE` to direct debug output to a custom log file.
 
 ## v1.0 – Initial Stable Release (2025-07-26)
 

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -61,6 +61,12 @@ parse_logging_flags() {
         LOG_FILE="${1#*=}"
         shift
         ;;
+      --debug=*)
+        DEBUG_MODE=1
+        FORCE_LOG=1
+        LOG_FILE="${1#*=}"
+        shift
+        ;;
       --debug)
         DEBUG_MODE=1
         FORCE_LOG=1

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the base-system setup: hostname/ifconfig/route,
@@ -53,7 +53,7 @@ show_help() {
 
   Options:
     -h, --help        Show this help message and exit
-    -d, --debug       Enable debug mode
+    -d, --debug       Enable debug mode (use --debug=FILE for custom file)
     -l, --log         Force log output (use --log=FILE for custom file)
 EOF
 }

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the GitHub sync setup: verifies that the SSH
@@ -54,7 +54,7 @@ show_help() {
 
   Options:
     -h, --help        Show this help message and exit
-    -d, --debug       Enable debug mode
+    -d, --debug       Enable debug mode (use --debug=FILE for custom file)
     -l, --log         Force log output (use --log=FILE for custom file)
 EOF
 }

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the local Obsidian vault used for Git-based
@@ -44,7 +44,7 @@ show_help() {
 
   Options:
     -h, --help        Show this help message and exit
-    -d, --debug       Enable debug mode
+    -d, --debug       Enable debug mode (use --debug=FILE for custom file)
     -l, --log         Force log output (use --log=FILE for custom file)
 EOF
 }

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: sh test.sh [--log[=FILE]] [--debug] [-h]
+# Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #
 # Description:
 #   Runs TAP-style checks against the Obsidian Git host setup: users/groups,
@@ -53,7 +53,7 @@ show_help() {
 
   Options:
     -h, --help        Show this help message and exit
-    -d, --debug       Enable debug mode
+    -d, --debug       Enable debug mode (use --debug=FILE for custom file)
     -l, --log         Force log output (use --log=FILE for custom file)
 EOF
 }

--- a/test_all.sh
+++ b/test_all.sh
@@ -5,7 +5,7 @@
 # Version: 1.0.0
 # Updated: 2025-07-28
 #
-# Usage: sh test_all.sh [--log[=FILE]] [--debug] [-h] [module1 module2 ...]
+# Usage: sh test_all.sh [--log[=FILE]] [--debug[=FILE]] [-h] [module1 module2 ...]
 #
 # Description:
 #   Executes each selected module's test.sh and reports a pass/fail summary.
@@ -60,7 +60,7 @@ show_help() {
 
   Options:
     -h, --help        Show this help message and exit
-    -d, --debug       Enable debug mode
+    -d, --debug       Enable debug mode (use --debug=FILE for custom file)
     -l, --log         Force log output (use --log=FILE for custom file)
 EOF
 }


### PR DESCRIPTION
## Summary
- allow passing `--debug=FILE` to direct debug output to a specific log
- document debug file support in test helpers and scripts
- note new debug file option in changelog

## Testing
- `sh test_all.sh --debug=custom.log base-system` *(fails: exit 1)*
- `sh modules/github/test.sh --debug=mygithub.log` *(fails: exit 1)*

------
https://chatgpt.com/codex/tasks/task_e_688cb1306c688327b9b7a8af7ddc7494