### PR TITLE
Remove dash from heredocs

### DIFF
--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -39,7 +39,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:
@@ -83,12 +83,12 @@ start_logging_if_debug "setup-$module_name" "$@"
 # 4) Networking config files
 ##############################################################################
 
-cat > "/etc/hostname.${INTERFACE}" <<-EOF
+cat > "/etc/hostname.${INTERFACE}" <<EOF
 inet ${GIT_SERVER} ${NETMASK}
 !route add default ${GATEWAY}
 EOF
 
-cat > /etc/resolv.conf <<-EOF
+cat > /etc/resolv.conf <<EOF
 nameserver ${DNS1}
 nameserver ${DNS2}
 EOF

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -45,7 +45,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -41,7 +41,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -46,7 +46,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -36,7 +36,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -39,7 +39,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:
@@ -108,7 +108,7 @@ usermod -G vault "$GIT_USER"
 # 6) doas config
 ##############################################################################
 
-cat > /etc/doas.conf <<-EOF
+cat > /etc/doas.conf <<EOF
 permit persist ${OBS_USER} as root
 permit nopass ${GIT_USER} as root cmd git*
 permit nopass ${GIT_USER} as ${OBS_USER} cmd git*
@@ -179,7 +179,7 @@ done
 WORK_DIR="/home/${OBS_USER}/vaults/${VAULT}"
 HOOK="$BARE_REPO/hooks/post-receive"
 
-cat > "$HOOK" <<-EOF
+cat > "$HOOK" <<EOF
 #!/bin/sh
 SHA=\$(cat "$BARE_REPO/refs/heads/master")
 su - $OBS_USER -c "/usr/local/bin/git --git-dir=$BARE_REPO --work-tree=$WORK_DIR checkout -f \$SHA"
@@ -218,7 +218,7 @@ find "$BARE_REPO" -type d -exec chmod g+s {} +
 
 for u in "$OBS_USER" "$GIT_USER"; do
   PROFILE="/home/$u/.profile"
-  cat <<-EOF >> "$PROFILE"
+  cat <<EOF >> "$PROFILE"
 export HISTFILE=/home/$u/.ksh_history
 export HISTSIZE=5000
 export HISTCONTROL=ignoredups

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -45,7 +45,7 @@ export PROJECT_ROOT
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:

--- a/test_all.sh
+++ b/test_all.sh
@@ -52,7 +52,7 @@ export PROJECT_ROOT MODULE_DIR
 ##############################################################################
 
 show_help() {
-  cat <<-EOF
+  cat <<EOF
   Usage: sh $(basename "$0") [options]
 
   Description:


### PR DESCRIPTION
## Summary
- Replace `<<-EOF` with `<<EOF` in scripts to avoid unintended indentation stripping
- Keep heredoc content unchanged for consistent output

## Testing
- `sh modules/github/test.sh -h`
- `sh modules/obsidian-git-host/setup.sh -h`
- `sh test_all.sh` *(fails: cannot read file system information for '%Lp')*

------
https://chatgpt.com/codex/tasks/task_e_688cba415c6c832798dd3bc55b8a1f32