### PR TITLE
docs: clarify logs directory purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Directory layout:
 ```
 openbsd-toolkit/
 ├── config/           # Secrets and module selection
-├── logs/             # Auto-created during runs
+├── logs/             # Contains logging.sh and generated log files
 ├── modules/          # One folder per module
-│   └── <module>/     
+│   └── <module>/
 │       ├── setup.sh  # Configures that module
 │       └── test.sh   # Verifies it works
 ├── install_modules.sh  # Installs selected modules


### PR DESCRIPTION
## Summary
- clarify README architecture entry for `logs/` to note `logging.sh` and generated logs

## Testing
- `sh test_all.sh` *(fails: Some tests FAILED - see log)*

------
https://chatgpt.com/codex/tasks/task_e_688d1e3e2e20832797e1bec93da4be64