### PR TITLE
docs: add planned modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,3 +34,6 @@
 - [ ] obsidian daily note scripts
 - [ ] Build a custom ISO
 - [ ] recovery partition 
+- [ ] VM hosting module
+- [ ] DNS self-host module
+- [ ] NAS hub module


### PR DESCRIPTION
## Summary
- add planned modules for VM hosting, DNS self-hosting, and NAS hub to TODO list

## Testing
- `bash test-all.sh` *(fails: Module 'base-system' FAILED, Module 'obsidian-git-host' FAILED, Module 'github' FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_688f7bc1b9cc8327b05355ccc87ebf46