### PR TITLE
Add idempotency comments for file creation commands

### DIFF
--- a/config/load-secrets.sh
+++ b/config/load-secrets.sh
@@ -36,7 +36,7 @@ SECRETS="$CONFIG_DIR/secrets.env"
 ##############################################################################
 
 if [ ! -f "$SECRETS" ]; then
-  cp "$EXAMPLE" "$SECRETS"
+  cp "$EXAMPLE" "$SECRETS"  # TODO: use state detection for idempotency
   echo "Created '$SECRETS' from example. Please edit it and re-run." >&2
   exit 1
 fi

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -148,7 +148,7 @@ init_logging() {
 
   LOG_DIR="$PROJECT_ROOT/logs"
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): creating LOG_DIR='$LOG_DIR'" >&2
-  mkdir -p "$LOG_DIR"
+  mkdir -p "$LOG_DIR"  # TODO: use state detection for idempotency
 
   if [ -z "$LOG_FILE" ]; then
     timestamp="$(date '+%Y%m%d_%H%M%S')"
@@ -172,12 +172,12 @@ init_logging() {
   if [ "$FORCE_LOG" -eq 1 ]; then
     [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): redirecting output to '$LOG_FILE'" >&2
     [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): enabling xtrace" >&2 && set -x
-    exec >>"$LOG_FILE" 2>&1
+    exec >>"$LOG_FILE" 2>&1  # TODO: use state detection for idempotency
   else
-    LOG_TMP="$(mktemp /tmp/logtmp.XXXXXXXX)"
+    LOG_TMP="$(mktemp /tmp/logtmp.XXXXXXXX)"  # TODO: use state detection for idempotency
     [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): buffering into '$LOG_TMP'" >&2
     export LOG_TMP
-    exec >"$LOG_TMP" 2>&1
+    exec >"$LOG_TMP" 2>&1  # TODO: use state detection for idempotency
   fi
 
   export LOGGING_INITIALIZED=1
@@ -199,7 +199,7 @@ finalize_logging() {
   if [ "$DEBUG_MODE" -eq 1 ] || [ "$FORCE_LOG" -eq 1 ] || [ "$TEST_FAILED" -eq 1 ]; then
     if [ -n "$LOG_TMP" ] && [ -f "$LOG_TMP" ]; then
       [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(finalize_logging): appending '$LOG_TMP' to '$LOG_FILE'" >&2
-      cat "$LOG_TMP" >>"$LOG_FILE"
+      cat "$LOG_TMP" >>"$LOG_FILE"  # TODO: use state detection for idempotency
       rm -f "$LOG_TMP"
       [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(finalize_logging): removed temp file" >&2
     fi

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -83,11 +83,13 @@ start_logging_if_debug "setup-$module_name" "$@"
 # 4) Networking config files
 ##############################################################################
 
+# TODO: use state detection for idempotency
 cat > "/etc/hostname.${INTERFACE}" <<EOF
 inet ${GIT_SERVER} ${NETMASK}
 !route add default ${GATEWAY}
 EOF
 
+# TODO: use state detection for idempotency
 cat > /etc/resolv.conf <<EOF
 nameserver ${DNS1}
 nameserver ${DNS2}
@@ -113,6 +115,7 @@ rcctl restart sshd
 # 7) Root history
 ##############################################################################
 
+# TODO: use state detection for idempotency
 cat << 'EOF' >> /root/.profile
 export HISTFILE=/root/.ksh_history
 export HISTSIZE=5000

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -87,11 +87,11 @@ DEPLOY_KEY="$PROJECT_ROOT/config/deploy_key"
 # 4) SSH setup (keys & known_hosts)
 ##############################################################################
 
-mkdir -p /root/.ssh
-cp "$DEPLOY_KEY" /root/.ssh/id_ed25519
+mkdir -p /root/.ssh  # TODO: use state detection for idempotency
+cp "$DEPLOY_KEY" /root/.ssh/id_ed25519  # TODO: use state detection for idempotency
 chmod 600 /root/.ssh/id_ed25519
 
-ssh-keyscan github.com >> /root/.ssh/known_hosts
+ssh-keyscan github.com >> /root/.ssh/known_hosts  # TODO: use state detection for idempotency
 
 : "LOCAL_DIR=$LOCAL_DIR"       # ensure variable is set
 : "GITHUB_REPO=$GITHUB_REPO"   # ensure variable is set
@@ -103,6 +103,6 @@ ssh-keyscan github.com >> /root/.ssh/known_hosts
 # 5) Repo bootstrap
 ##############################################################################
 
-git clone "$GITHUB_REPO" "$LOCAL_DIR"
+git clone "$GITHUB_REPO" "$LOCAL_DIR"  # TODO: use state detection for idempotency
 
 echo "github: GitHub configuration complete!"

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -145,7 +145,7 @@ run_tests() {
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): creating and pushing test commit" >&2
   cd "$LOCAL_VAULT" || return 1
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG: creating test commit in $LOCAL_VAULT" >&2
-  echo "# test $(date +%s)" >> test-sync.md
+  echo "# test $(date +%s)" >> test-sync.md  # TODO: use state detection for idempotency
   git add test-sync.md >/dev/null 2>&1
   if [ "$DEBUG_MODE" -eq 1 ]; then
     git commit -m "TDD sync test" >&2

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -108,6 +108,7 @@ usermod -G vault "$GIT_USER"
 # 6) doas config
 ##############################################################################
 
+# TODO: use state detection for idempotency
 cat > /etc/doas.conf <<EOF
 permit persist ${OBS_USER} as root
 permit nopass ${GIT_USER} as root cmd git*
@@ -124,7 +125,7 @@ chmod 0440 /etc/doas.conf
 if grep -q '^AllowUsers ' /etc/ssh/sshd_config; then
   sed -i "/^AllowUsers /c\\AllowUsers ${OBS_USER} ${GIT_USER}" /etc/ssh/sshd_config
 else
-  echo "AllowUsers ${OBS_USER} ${GIT_USER}" >> /etc/ssh/sshd_config
+  echo "AllowUsers ${OBS_USER} ${GIT_USER}" >> /etc/ssh/sshd_config  # TODO: use state detection for idempotency
 fi
 rcctl restart sshd
 
@@ -132,15 +133,15 @@ rcctl restart sshd
 for u in "$OBS_USER" "$GIT_USER"; do
   HOME_DIR="/home/$u"
   SSH_DIR="$HOME_DIR/.ssh"
-  mkdir -p "$SSH_DIR"
+  mkdir -p "$SSH_DIR"  # TODO: use state detection for idempotency
   chmod 700 "$SSH_DIR"
-  touch "$SSH_DIR/authorized_keys"
+  touch "$SSH_DIR/authorized_keys"  # TODO: use state detection for idempotency
   chmod 600 "$SSH_DIR/authorized_keys"
   chown -R "$u:$u" "$SSH_DIR"
 done
 
 # 7.3 Known Hosts (OBS_USER only)
-ssh-keyscan -H "$GIT_SERVER" >> "/home/${OBS_USER}/.ssh/known_hosts"
+ssh-keyscan -H "$GIT_SERVER" >> "/home/${OBS_USER}/.ssh/known_hosts"  # TODO: use state detection for idempotency
 chmod 644 "/home/${OBS_USER}/.ssh/known_hosts"
 chown "${OBS_USER}:${OBS_USER}" "/home/${OBS_USER}/.ssh/known_hosts"
 
@@ -150,10 +151,10 @@ chown "${OBS_USER}:${OBS_USER}" "/home/${OBS_USER}/.ssh/known_hosts"
 
 VAULT_DIR="/home/${GIT_USER}/vaults"
 BARE_REPO="${VAULT_DIR}/${VAULT}.git"
-mkdir -p "$VAULT_DIR"
+mkdir -p "$VAULT_DIR"  # TODO: use state detection for idempotency
 chown "${GIT_USER}:${GIT_USER}" "$VAULT_DIR"
 
-git init --bare "$BARE_REPO"
+git init --bare "$BARE_REPO"  # TODO: use state detection for idempotency
 chown -R "${GIT_USER}:${GIT_USER}" "$BARE_REPO"
 
 ##############################################################################
@@ -162,7 +163,7 @@ chown -R "${GIT_USER}:${GIT_USER}" "$BARE_REPO"
 
 for u in "$GIT_USER" "$OBS_USER"; do
   cfg="/home/$u/.gitconfig"
-  touch "$cfg"
+  touch "$cfg"  # TODO: use state detection for idempotency
   if [ "$u" = "$GIT_USER" ]; then
     git config --file "$cfg" --add safe.directory "$BARE_REPO"
     git config --file "$cfg" --add safe.directory "/home/${OBS_USER}/vaults/${VAULT}"
@@ -179,6 +180,7 @@ done
 WORK_DIR="/home/${OBS_USER}/vaults/${VAULT}"
 HOOK="$BARE_REPO/hooks/post-receive"
 
+# TODO: use state detection for idempotency
 cat > "$HOOK" <<EOF
 #!/bin/sh
 SHA=\$(cat "$BARE_REPO/refs/heads/master")
@@ -193,8 +195,8 @@ chmod +x "$HOOK"
 # 11) Working copy clone & initial commit
 ##############################################################################
 
-mkdir -p "$(dirname "$WORK_DIR")"
-git -c safe.directory="$BARE_REPO" clone "$BARE_REPO" "$WORK_DIR"
+mkdir -p "$(dirname "$WORK_DIR")"  # TODO: use state detection for idempotency
+git -c safe.directory="$BARE_REPO" clone "$BARE_REPO" "$WORK_DIR"  # TODO: use state detection for idempotency
 chown -R "${OBS_USER}:${OBS_USER}" "$WORK_DIR"
 
 git -C "$WORK_DIR" \
@@ -218,6 +220,7 @@ find "$BARE_REPO" -type d -exec chmod g+s {} +
 
 for u in "$OBS_USER" "$GIT_USER"; do
   PROFILE="/home/$u/.profile"
+  # TODO: use state detection for idempotency
   cat <<EOF >> "$PROFILE"
 export HISTFILE=/home/$u/.ksh_history
 export HISTSIZE=5000


### PR DESCRIPTION
## Summary
- note file copy in secrets bootstrap should check state
- remind to ensure idempotency for logging temp files and output
- flag setup scripts and tests where directories/files are created

## Testing
- `bash test-all.sh` *(fails: deploy key mode is 600, known_hosts missing, repository was not cloned)*

------
https://chatgpt.com/codex/tasks/task_e_688fa6bfdc90832784cacc05d4448301