### PR TITLE
Align idempotency comments across modules

### DIFF
--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -83,39 +83,45 @@ start_logging_if_debug "setup-$module_name" "$@"
 # 4) Networking config files
 ##############################################################################
 
-# TODO: use state detection for idempotency (Safe editing or replace+template with checksum); add rollback handling and dry-run mode
+# TODO: Idempotency: Use state detection (safe editing or replace+template with checksum); rollback handling and dry-run mode
 cat > "/etc/hostname.${INTERFACE}" <<EOF
 inet ${GIT_SERVER} ${NETMASK}
 !route add default ${GATEWAY}
 EOF
 
-# TODO: use state detection for idempotency (Safe editing or replace+template with checksum); add rollback handling and dry-run mode
+# TODO: Idempotency: Use state detection (safe editing or replace+template with checksum); rollback handling and dry-run mode
 cat > /etc/resolv.conf <<EOF
 nameserver ${DNS1}
 nameserver ${DNS2}
 EOF
-chmod 644 /etc/resolv.conf  # TODO: ensure idempotency via rollback handling and dry-run mode
+# TODO: Idempotency: Rollback handling and dry-run mode
+chmod 644 /etc/resolv.conf
 
 ##############################################################################
 # 5) Apply networking
 ##############################################################################
 
-ifconfig "${INTERFACE}" inet "${GIT_SERVER}" netmask "${NETMASK}" up  # TODO: ensure idempotency via rollback handling and dry-run mode
-route add default "${GATEWAY}"  # TODO: ensure idempotency via rollback handling and dry-run mode
+# TODO: Idempotency: Rollback handling and dry-run mode
+ifconfig "${INTERFACE}" inet "${GIT_SERVER}" netmask "${NETMASK}" up
+# TODO: Idempotency: Rollback handling and dry-run mode
+route add default "${GATEWAY}"
 
 ##############################################################################
 # 6) SSH hardening
 ##############################################################################
 
-sed -i 's/^#*PermitRootLogin .*/PermitRootLogin no/' /etc/ssh/sshd_config  # TODO: ensure idempotency via Safe editing or replace+template with checksum; add rollback handling and dry-run mode
-sed -i 's/^#*PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config  # TODO: ensure idempotency via Safe editing or replace+template with checksum; add rollback handling and dry-run mode
-rcctl restart sshd  # TODO: ensure idempotency via rollback handling and dry-run mode
+# TODO: Idempotency: Safe editing or replace+template with checksum; rollback handling and dry-run mode
+sed -i 's/^#*PermitRootLogin .*/PermitRootLogin no/' /etc/ssh/sshd_config
+# TODO: Idempotency: Safe editing or replace+template with checksum; rollback handling and dry-run mode
+sed -i 's/^#*PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config
+# TODO: Idempotency: Rollback handling and dry-run mode
+rcctl restart sshd
 
 ##############################################################################
 # 7) Root history
 ##############################################################################
 
-# TODO: use state detection for idempotency (Safe editing or replace+template with checksum); add rollback handling and dry-run mode
+# TODO: Idempotency: Use state detection (safe editing or replace+template with checksum); rollback handling and dry-run mode
 cat << 'EOF' >> /root/.profile
 export HISTFILE=/root/.ksh_history
 export HISTSIZE=5000

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -87,11 +87,15 @@ DEPLOY_KEY="$PROJECT_ROOT/config/deploy_key"
 # 4) SSH setup (keys & known_hosts)
 ##############################################################################
 
-mkdir -p /root/.ssh  # TODO: use state detection for idempotency; add rollback handling and dry-run mode
-cp "$DEPLOY_KEY" /root/.ssh/id_ed25519  # TODO: use state detection for idempotency; add rollback handling and dry-run mode
-chmod 600 /root/.ssh/id_ed25519  # TODO: ensure idempotency via rollback handling and dry-run mode
+# TODO: Idempotency: State detection; rollback handling and dry-run mode
+mkdir -p /root/.ssh
+# TODO: Idempotency: State detection; rollback handling and dry-run mode
+cp "$DEPLOY_KEY" /root/.ssh/id_ed25519
+# TODO: Idempotency: Rollback handling and dry-run mode
+chmod 600 /root/.ssh/id_ed25519
 
-ssh-keyscan github.com >> /root/.ssh/known_hosts  # TODO: use state detection for idempotency (Safe editing or replace+template with checksum); add rollback handling and dry-run mode
+# TODO: Idempotency: State detection; safe editing or replace+template with checksum; rollback handling and dry-run mode
+ssh-keyscan github.com >> /root/.ssh/known_hosts
 
 : "LOCAL_DIR=$LOCAL_DIR"       # ensure variable is set
 : "GITHUB_REPO=$GITHUB_REPO"   # ensure variable is set
@@ -103,6 +107,7 @@ ssh-keyscan github.com >> /root/.ssh/known_hosts  # TODO: use state detection fo
 # 5) Repo bootstrap
 ##############################################################################
 
-git clone "$GITHUB_REPO" "$LOCAL_DIR"  # TODO: use state detection for idempotency; add rollback handling and dry-run mode
+# TODO: Idempotency: State detection; rollback handling and dry-run mode
+git clone "$GITHUB_REPO" "$LOCAL_DIR"
 
 echo "github: GitHub configuration complete!"


### PR DESCRIPTION
## Summary
- standardize idempotency TODO comments in base-system module
- match GitHub module idempotency comments to obsidian-git-host style

## Testing
- `sh modules/base-system/test.sh` *(fails: netstat, sshd_config, rcctl, and root profile settings missing)*
- `sh modules/github/test.sh` *(fails: deploy key, known_hosts, and cloned repository missing)*

------
https://chatgpt.com/codex/tasks/task_e_68900c65410083278c60405bbb4d38f3