### PR TITLE
docs: outline rollback and dry-run strategy

### DIFF
--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -36,6 +36,28 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 export PROJECT_ROOT
 
+# -----------------------------------------------------------------------------
+# Idempotency helpers (commented out until dry-run/rollback is implemented)
+# -----------------------------------------------------------------------------
+# DRY_RUN="false"
+# ROLLBACK_CMDS=""
+# run_cmd() {
+#   _cmd="$1"
+#   _rollback="$2"
+#   if [ "$DRY_RUN" = "true" ]; then
+#     printf '[DRY RUN] %s\n' "$_cmd"
+#   else
+#     eval "$_cmd"
+#     ROLLBACK_CMDS="$_rollback\n$ROLLBACK_CMDS"
+#   fi
+# }
+# rollback() {
+#   printf '%s' "$ROLLBACK_CMDS" | while IFS= read -r _rb; do
+#     [ -n "$_rb" ] && eval "$_rb"
+#   done
+# }
+# trap rollback EXIT
+
 ##############################################################################
 # 1) Help & banned flags prescan
 ##############################################################################
@@ -89,16 +111,20 @@ DEPLOY_KEY="$PROJECT_ROOT/config/deploy_key"
 
 # TODO: Idempotency: State detection
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "mkdir -p /root/.ssh" "rmdir /root/.ssh"
 mkdir -p /root/.ssh
 # TODO: Idempotency: State detection
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "cp \"$DEPLOY_KEY\" /root/.ssh/id_ed25519" "rm -f /root/.ssh/id_ed25519"
 cp "$DEPLOY_KEY" /root/.ssh/id_ed25519
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "chmod 600 /root/.ssh/id_ed25519" "chmod 000 /root/.ssh/id_ed25519"
 chmod 600 /root/.ssh/id_ed25519
 
 # TODO: Idempotency: State detection
 # TODO: Idempotency: safe editing or replace+template with checksum
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "ssh-keyscan github.com >> /root/.ssh/known_hosts" "sed -i '/github.com/d' /root/.ssh/known_hosts"
 ssh-keyscan github.com >> /root/.ssh/known_hosts
 
 : "LOCAL_DIR=$LOCAL_DIR"       # ensure variable is set
@@ -113,6 +139,7 @@ ssh-keyscan github.com >> /root/.ssh/known_hosts
 
 # TODO: Idempotency: State detection
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "git clone \"$GITHUB_REPO\" \"$LOCAL_DIR\"" "rm -rf \"$LOCAL_DIR\""
 git clone "$GITHUB_REPO" "$LOCAL_DIR"
 
 echo "github: GitHub configuration complete!"

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -34,6 +34,28 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 export PROJECT_ROOT
 
+# -----------------------------------------------------------------------------
+# Idempotency helpers (commented out until dry-run/rollback is implemented)
+# -----------------------------------------------------------------------------
+# DRY_RUN="false"
+# ROLLBACK_CMDS=""
+# run_cmd() {
+#   _cmd="$1"
+#   _rollback="$2"
+#   if [ "$DRY_RUN" = "true" ]; then
+#     printf '[DRY RUN] %s\n' "$_cmd"
+#   else
+#     eval "$_cmd"
+#     ROLLBACK_CMDS="$_rollback\n$ROLLBACK_CMDS"
+#   fi
+# }
+# rollback() {
+#   printf '%s' "$ROLLBACK_CMDS" | while IFS= read -r _rb; do
+#     [ -n "$_rb" ] && eval "$_rb"
+#   done
+# }
+# trap rollback EXIT
+
 ##############################################################################
 # 1) Help & banned flags prescan
 ##############################################################################
@@ -88,6 +110,7 @@ start_logging_if_debug "setup-$module_name" "$@"
 ##############################################################################
 
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "pkg_add -v git" "pkg_delete git"
 pkg_add -v git
 
 ##############################################################################
@@ -97,17 +120,22 @@ for u in "$OBS_USER" "$GIT_USER"; do
   shell_path=$([ "$u" = "$OBS_USER" ] && echo '/bin/ksh' || echo '/usr/local/bin/git-shell')
   if ! id "$u" >/dev/null 2>&1; then
       # TODO: Idempotency: Rollback handling and dry-run mode
+      # run_cmd "useradd -m -s $shell_path $u" "userdel $u"
       useradd -m -s "$shell_path" "$u"
       # TODO: Idempotency: Rollback handling and dry-run mode
+      # run_cmd "usermod -p '' $u" "passwd -l $u"
       usermod -p '' "$u"
   fi
 done
 
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "groupadd vault" "groupdel vault"
 groupadd vault || true
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "usermod -G vault $OBS_USER" "usermod -G '' $OBS_USER"
 usermod -G vault "$OBS_USER"
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "usermod -G vault $GIT_USER" "usermod -G '' $GIT_USER"
 usermod -G vault "$GIT_USER"
 
 ##############################################################################
@@ -116,14 +144,17 @@ usermod -G vault "$GIT_USER"
 
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
+# run_cmd "cat > /etc/doas.conf" "rm -f /etc/doas.conf"
 cat > /etc/doas.conf <<EOF
 permit persist ${OBS_USER} as root
 permit nopass ${GIT_USER} as root cmd git*
 permit nopass ${GIT_USER} as ${OBS_USER} cmd git*
 EOF
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "chown root:wheel /etc/doas.conf" "chown root:wheel /etc/doas.conf"
 chown root:wheel /etc/doas.conf
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "chmod 0440 /etc/doas.conf" "chmod 0644 /etc/doas.conf"
 chmod 0440 /etc/doas.conf
 
 ##############################################################################
@@ -134,13 +165,16 @@ chmod 0440 /etc/doas.conf
   if grep -q '^AllowUsers ' /etc/ssh/sshd_config; then
     # TODO: idempotency: Safe editing or replace+template with checksum
     # TODO: idempotency: rollback handling and dry-run mode
+    # run_cmd "cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak && sed -i \"/^AllowUsers /c\\AllowUsers ${OBS_USER} ${GIT_USER}\" /etc/ssh/sshd_config" "mv /etc/ssh/sshd_config.bak /etc/ssh/sshd_config"
     sed -i "/^AllowUsers /c\\AllowUsers ${OBS_USER} ${GIT_USER}" /etc/ssh/sshd_config
   else
     # TODO: idempotency: Safe editing or replace+template with checksum
     # TODO: idempotency: rollback handling and dry-run mode
+    # run_cmd "echo AllowUsers ${OBS_USER} ${GIT_USER} >> /etc/ssh/sshd_config" "sed -i '/AllowUsers ${OBS_USER} ${GIT_USER}/d' /etc/ssh/sshd_config"
     echo "AllowUsers ${OBS_USER} ${GIT_USER}" >> /etc/ssh/sshd_config
   fi
   # TODO: Idempotency: Rollback handling and dry-run mode
+  # run_cmd "rcctl restart sshd" "rcctl restart sshd"
   rcctl restart sshd
 
 # 7.2 .ssh Directories and authorized users
@@ -149,15 +183,20 @@ for u in "$OBS_USER" "$GIT_USER"; do
   SSH_DIR="$HOME_DIR/.ssh"
     # TODO: idempotency: state detection
     # TODO: idempotency: rollback handling and dry-run mode
+    # run_cmd "mkdir -p $SSH_DIR" "rmdir $SSH_DIR"
     mkdir -p "$SSH_DIR"
     # TODO: Idempotency: Rollback handling and dry-run mode
+    # run_cmd "chmod 700 $SSH_DIR" "chmod 755 $SSH_DIR"
     chmod 700 "$SSH_DIR"
     # TODO: idempotency: state detection
     # TODO: idempotency: rollback handling and dry-run mode
+    # run_cmd "touch $SSH_DIR/authorized_keys" "rm -f $SSH_DIR/authorized_keys"
     touch "$SSH_DIR/authorized_keys"
     # TODO: Idempotency: Rollback handling and dry-run mode
+    # run_cmd "chmod 600 $SSH_DIR/authorized_keys" "chmod 644 $SSH_DIR/authorized_keys"
     chmod 600 "$SSH_DIR/authorized_keys"
     # TODO: Idempotency: Rollback handling and dry-run mode
+    # run_cmd "chown -R $u:$u $SSH_DIR" "chown -R root:wheel $SSH_DIR"
     chown -R "$u:$u" "$SSH_DIR"
 done
 
@@ -165,10 +204,13 @@ done
 # TODO: idempotency: state detection
 # TODO: idempotency: Safe editing or replace+template with checksum
 # TODO: idempotency: rollback handling and dry-run mode
+# run_cmd "ssh-keyscan -H $GIT_SERVER >> /home/${OBS_USER}/.ssh/known_hosts" "sed -i '/$GIT_SERVER/d' /home/${OBS_USER}/.ssh/known_hosts"
 ssh-keyscan -H "$GIT_SERVER" >> "/home/${OBS_USER}/.ssh/known_hosts"
 # TODO: idempotency rollback handling and dry-run mode
+# run_cmd "chmod 644 /home/${OBS_USER}/.ssh/known_hosts" "chmod 600 /home/${OBS_USER}/.ssh/known_hosts"
 chmod 644 "/home/${OBS_USER}/.ssh/known_hosts"
 # TODO: idempotency rollback handling and dry-run mode
+# run_cmd "chown ${OBS_USER}:${OBS_USER} /home/${OBS_USER}/.ssh/known_hosts" "chown root:wheel /home/${OBS_USER}/.ssh/known_hosts"
 chown "${OBS_USER}:${OBS_USER}" "/home/${OBS_USER}/.ssh/known_hosts"
 
 ##############################################################################
@@ -179,16 +221,20 @@ VAULT_DIR="/home/${GIT_USER}/vaults"
 BARE_REPO="${VAULT_DIR}/${VAULT}.git"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
+# run_cmd "mkdir -p $VAULT_DIR" "rmdir $VAULT_DIR"
 mkdir -p "$VAULT_DIR"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
+# run_cmd "chown ${GIT_USER}:${GIT_USER} $VAULT_DIR" "chown root:wheel $VAULT_DIR"
 chown "${GIT_USER}:${GIT_USER}" "$VAULT_DIR"
 
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
+# run_cmd "git init --bare $BARE_REPO" "rm -rf $BARE_REPO"
 git init --bare "$BARE_REPO"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
+# run_cmd "chown -R ${GIT_USER}:${GIT_USER} $BARE_REPO" "chown -R root:wheel $BARE_REPO"
 chown -R "${GIT_USER}:${GIT_USER}" "$BARE_REPO"
 
 ##############################################################################
@@ -199,20 +245,25 @@ for u in "$GIT_USER" "$OBS_USER"; do
   cfg="/home/$u/.gitconfig"
     # TODO: idempotency: state detection
     # TODO: idempotency: rollback handling and dry-run mode
+    # run_cmd "touch $cfg" "rm -f $cfg"
     touch "$cfg"
   if [ "$u" = "$GIT_USER" ]; then
       # TODO: idempotency: Safe editing or replace+template with checksum
       # TODO: idempotency: rollback handling and dry-run mode
+      # run_cmd "git config --file $cfg --add safe.directory $BARE_REPO" "git config --file $cfg --unset-all safe.directory $BARE_REPO"
       git config --file "$cfg" --add safe.directory "$BARE_REPO"
       # TODO: idempotency: Safe editing or replace+template with checksum
       # TODO: idempotency: rollback handling and dry-run mode
+      # run_cmd "git config --file $cfg --add safe.directory /home/${OBS_USER}/vaults/${VAULT}" "git config --file $cfg --unset-all safe.directory /home/${OBS_USER}/vaults/${VAULT}"
       git config --file "$cfg" --add safe.directory "/home/${OBS_USER}/vaults/${VAULT}"
   else
       # TODO: idempotency: Safe editing or replace+template with checksum
       # TODO: idempotency: rollback handling and dry-run mode
+      # run_cmd "git config --file $cfg --add safe.directory /home/${OBS_USER}/vaults/${VAULT}" "git config --file $cfg --unset-all safe.directory /home/${OBS_USER}/vaults/${VAULT}"
       git config --file "$cfg" --add safe.directory "/home/${OBS_USER}/vaults/${VAULT}"
   fi
     # TODO: Idempotency: Rollback handling and dry-run mode
+    # run_cmd "chown $u:$u $cfg" "chown root:wheel $cfg"
     chown "$u:$u" "$cfg"
 done
 
@@ -226,6 +277,7 @@ HOOK="$BARE_REPO/hooks/post-receive"
 # TODO: Idempotency: state detection
 # TODO: Idempotency: Safe editing or replace+template with checksum
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "cat > $HOOK" "rm -f $HOOK"
 cat > "$HOOK" <<EOF
 #!/bin/sh
 SHA=\$(cat "$BARE_REPO/refs/heads/master")
@@ -234,8 +286,10 @@ exit 0
 EOF
 
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "chown ${GIT_USER}:${GIT_USER} $HOOK" "chown root:wheel $HOOK"
 chown "${GIT_USER}:${GIT_USER}" "$HOOK"
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "chmod +x $HOOK" "chmod -x $HOOK"
 chmod +x "$HOOK"
 
 ##############################################################################
@@ -244,14 +298,18 @@ chmod +x "$HOOK"
 
 # TODO: Idempotency: State detection
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "mkdir -p $(dirname $WORK_DIR)" "rmdir $(dirname $WORK_DIR)"
 mkdir -p "$(dirname "$WORK_DIR")"
 # TODO: Idempotency: State detection
 # TODO: Idempotency: Rollback handling and dry-run mode
+# run_cmd "git -c safe.directory=$BARE_REPO clone $BARE_REPO $WORK_DIR" "rm -rf $WORK_DIR"
 git -c safe.directory="$BARE_REPO" clone "$BARE_REPO" "$WORK_DIR"
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "chown -R ${OBS_USER}:${OBS_USER} $WORK_DIR" "chown -R root:wheel $WORK_DIR"
 chown -R "${OBS_USER}:${OBS_USER}" "$WORK_DIR"
 
 # TODO: Idempotency: rollback handling and dry-run mode
+  # run_cmd "git -C $WORK_DIR -c safe.directory=$WORK_DIR -c user.name='Obsidian User' -c user.email='obsidian@example.com' commit --allow-empty -m 'initial commit'" "git -C $WORK_DIR reset --hard HEAD~1"
   git -C "$WORK_DIR" \
       -c safe.directory="$WORK_DIR" \
       -c user.name='Obsidian User' \
@@ -263,12 +321,16 @@ chown -R "${OBS_USER}:${OBS_USER}" "$WORK_DIR"
 ##############################################################################
 
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "git --git-dir=$BARE_REPO config core.sharedRepository group" "git --git-dir=$BARE_REPO config --unset core.sharedRepository"
 git --git-dir="$BARE_REPO" config core.sharedRepository group
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "chown -R ${GIT_USER}:vault $BARE_REPO" "chown -R root:wheel $BARE_REPO"
 chown -R "${GIT_USER}:vault" "$BARE_REPO"
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "chmod -R g+rwX $BARE_REPO" "chmod -R go-rwx $BARE_REPO"
 chmod -R g+rwX "$BARE_REPO"
 # TODO: Idempotency: rollback handling and dry-run mode
+# run_cmd "find $BARE_REPO -type d -exec chmod g+s {} +" "find $BARE_REPO -type d -exec chmod g-s {} +"
 find "$BARE_REPO" -type d -exec chmod g+s {} +
 
 ##############################################################################
@@ -280,12 +342,14 @@ for u in "$OBS_USER" "$GIT_USER"; do
       # TODO: Idempotency: State detection
       # TODO: Idempotency: Safe editing or replace+template with checksum
       # TODO: Idempotency: Rollback handling and dry-run mode
+      # run_cmd "cat >> $PROFILE" "cp ${PROFILE}.bak $PROFILE"
       cat <<EOF >> "$PROFILE"
 export HISTFILE=/home/$u/.ksh_history
 export HISTSIZE=5000
 export HISTCONTROL=ignoredups
 EOF
     # TODO: Idempotency: Rollback handling and dry-run mode
+    # run_cmd "chown $u:$u $PROFILE" "chown root:wheel $PROFILE"
     chown "$u:$u" "$PROFILE"
 done
 


### PR DESCRIPTION
## Summary
- add commented dry-run and rollback helpers across setup scripts
- sketch rollback commands for user, file, and repo actions

## Testing
- `sh test-all.sh`
- `shellcheck modules/github/setup.sh modules/base-system/setup.sh modules/obsidian-git-host/setup.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689018bcdc388327ad131616f06dde92