### PR TITLE
docs: add idempotency state detection comments

### DIFF
--- a/config/load-secrets.sh
+++ b/config/load-secrets.sh
@@ -36,6 +36,7 @@ SECRETS="$CONFIG_DIR/secrets.env"
 ##############################################################################
 
 if [ ! -f "$SECRETS" ]; then
+  # cmp -s "$EXAMPLE" "$SECRETS" || cp "$EXAMPLE" "$SECRETS"
   cp "$EXAMPLE" "$SECRETS"  # TODO: use state detection for idempotency
   echo "Created '$SECRETS' from example. Please edit it and re-run." >&2
   exit 1

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -148,6 +148,7 @@ init_logging() {
 
   LOG_DIR="$PROJECT_ROOT/logs"
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): creating LOG_DIR='$LOG_DIR'" >&2
+  # [ -d "$LOG_DIR" ] || mkdir -p "$LOG_DIR"
   mkdir -p "$LOG_DIR"  # TODO: use state detection for idempotency
 
   if [ -z "$LOG_FILE" ]; then
@@ -172,11 +173,14 @@ init_logging() {
   if [ "$FORCE_LOG" -eq 1 ]; then
     [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): redirecting output to '$LOG_FILE'" >&2
     [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): enabling xtrace" >&2 && set -x
+    # [ "$(ls -l /proc/$$/fd/1 2>/dev/null | awk '{print $NF}')" = "$LOG_FILE" ] || exec >>"$LOG_FILE" 2>&1
     exec >>"$LOG_FILE" 2>&1  # TODO: use state detection for idempotency
   else
+    # [ -n "$LOG_TMP" ] || LOG_TMP="$(mktemp /tmp/logtmp.XXXXXXXX)"
     LOG_TMP="$(mktemp /tmp/logtmp.XXXXXXXX)"  # TODO: use state detection for idempotency
     [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(init_logging): buffering into '$LOG_TMP'" >&2
     export LOG_TMP
+    # [ "$(ls -l /proc/$$/fd/1 2>/dev/null | awk '{print $NF}')" = "$LOG_TMP" ] || exec >"$LOG_TMP" 2>&1
     exec >"$LOG_TMP" 2>&1  # TODO: use state detection for idempotency
   fi
 
@@ -199,6 +203,7 @@ finalize_logging() {
   if [ "$DEBUG_MODE" -eq 1 ] || [ "$FORCE_LOG" -eq 1 ] || [ "$TEST_FAILED" -eq 1 ]; then
     if [ -n "$LOG_TMP" ] && [ -f "$LOG_TMP" ]; then
       [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(finalize_logging): appending '$LOG_TMP' to '$LOG_FILE'" >&2
+      # [ -s "$LOG_TMP" ] && cat "$LOG_TMP" >>"$LOG_FILE"
       cat "$LOG_TMP" >>"$LOG_FILE"  # TODO: use state detection for idempotency
       rm -f "$LOG_TMP"
       [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(finalize_logging): removed temp file" >&2

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -145,6 +145,7 @@ run_tests() {
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): creating and pushing test commit" >&2
   cd "$LOCAL_VAULT" || return 1
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG: creating test commit in $LOCAL_VAULT" >&2
+  # grep -q '^# test' test-sync.md || echo "# test $(date +%s)" >> test-sync.md
   echo "# test $(date +%s)" >> test-sync.md  # TODO: use state detection for idempotency
   git add test-sync.md >/dev/null 2>&1
   if [ "$DEBUG_MODE" -eq 1 ]; then

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -145,11 +145,14 @@ usermod -G vault "$GIT_USER"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
 # run_cmd "cat > /etc/doas.conf" "rm -f /etc/doas.conf"
+# if ! grep -q "permit persist ${OBS_USER} as root" /etc/doas.conf 2>/dev/null; then
+# cat > /etc/doas.conf <<EOF
 cat > /etc/doas.conf <<EOF
 permit persist ${OBS_USER} as root
 permit nopass ${GIT_USER} as root cmd git*
 permit nopass ${GIT_USER} as ${OBS_USER} cmd git*
 EOF
+# fi
 # TODO: Idempotency: Rollback handling and dry-run mode
 # run_cmd "chown root:wheel /etc/doas.conf" "chown root:wheel /etc/doas.conf"
 chown root:wheel /etc/doas.conf
@@ -184,6 +187,7 @@ for u in "$OBS_USER" "$GIT_USER"; do
     # TODO: idempotency: state detection
     # TODO: idempotency: rollback handling and dry-run mode
     # run_cmd "mkdir -p $SSH_DIR" "rmdir $SSH_DIR"
+    # [ -d "$SSH_DIR" ] || mkdir -p "$SSH_DIR"
     mkdir -p "$SSH_DIR"
     # TODO: Idempotency: Rollback handling and dry-run mode
     # run_cmd "chmod 700 $SSH_DIR" "chmod 755 $SSH_DIR"
@@ -191,6 +195,7 @@ for u in "$OBS_USER" "$GIT_USER"; do
     # TODO: idempotency: state detection
     # TODO: idempotency: rollback handling and dry-run mode
     # run_cmd "touch $SSH_DIR/authorized_keys" "rm -f $SSH_DIR/authorized_keys"
+    # [ -f "$SSH_DIR/authorized_keys" ] || touch "$SSH_DIR/authorized_keys"
     touch "$SSH_DIR/authorized_keys"
     # TODO: Idempotency: Rollback handling and dry-run mode
     # run_cmd "chmod 600 $SSH_DIR/authorized_keys" "chmod 644 $SSH_DIR/authorized_keys"
@@ -205,6 +210,7 @@ done
 # TODO: idempotency: Safe editing or replace+template with checksum
 # TODO: idempotency: rollback handling and dry-run mode
 # run_cmd "ssh-keyscan -H $GIT_SERVER >> /home/${OBS_USER}/.ssh/known_hosts" "sed -i '/$GIT_SERVER/d' /home/${OBS_USER}/.ssh/known_hosts"
+# grep -q "$GIT_SERVER" /home/${OBS_USER}/.ssh/known_hosts || ssh-keyscan -H "$GIT_SERVER" >> "/home/${OBS_USER}/.ssh/known_hosts"
 ssh-keyscan -H "$GIT_SERVER" >> "/home/${OBS_USER}/.ssh/known_hosts"
 # TODO: idempotency rollback handling and dry-run mode
 # run_cmd "chmod 644 /home/${OBS_USER}/.ssh/known_hosts" "chmod 600 /home/${OBS_USER}/.ssh/known_hosts"
@@ -222,19 +228,23 @@ BARE_REPO="${VAULT_DIR}/${VAULT}.git"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
 # run_cmd "mkdir -p $VAULT_DIR" "rmdir $VAULT_DIR"
+# [ -d "$VAULT_DIR" ] || mkdir -p "$VAULT_DIR"
 mkdir -p "$VAULT_DIR"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
 # run_cmd "chown ${GIT_USER}:${GIT_USER} $VAULT_DIR" "chown root:wheel $VAULT_DIR"
+# [ "$(stat -f %Su \"$VAULT_DIR\" 2>/dev/null)" = "$GIT_USER" ] || chown "${GIT_USER}:${GIT_USER}" "$VAULT_DIR"
 chown "${GIT_USER}:${GIT_USER}" "$VAULT_DIR"
 
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
 # run_cmd "git init --bare $BARE_REPO" "rm -rf $BARE_REPO"
+# [ -d "$BARE_REPO" ] || git init --bare "$BARE_REPO"
 git init --bare "$BARE_REPO"
 # TODO: idempotency: state detection
 # TODO: idempotency: rollback handling and dry-run mode
 # run_cmd "chown -R ${GIT_USER}:${GIT_USER} $BARE_REPO" "chown -R root:wheel $BARE_REPO"
+# [ "$(stat -f %Su \"$BARE_REPO\" 2>/dev/null)" = "$GIT_USER" ] || chown -R "${GIT_USER}:${GIT_USER}" "$BARE_REPO"
 chown -R "${GIT_USER}:${GIT_USER}" "$BARE_REPO"
 
 ##############################################################################
@@ -246,6 +256,7 @@ for u in "$GIT_USER" "$OBS_USER"; do
     # TODO: idempotency: state detection
     # TODO: idempotency: rollback handling and dry-run mode
     # run_cmd "touch $cfg" "rm -f $cfg"
+    # [ -f "$cfg" ] || touch "$cfg"
     touch "$cfg"
   if [ "$u" = "$GIT_USER" ]; then
       # TODO: idempotency: Safe editing or replace+template with checksum


### PR DESCRIPTION
## Summary
- add commented idempotency checks around logging setup and teardown
- document optional idempotency copy guard for secrets loading
- outline commented state checks for git test helper and host setup script

## Testing
- `sh ./test-all.sh >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(fails: "Some tests FAILED - see log at /workspace/openbsd-toolkit/logs/test-all-20250804_024011.log")*

------
https://chatgpt.com/codex/tasks/task_e_68901cb90cec8327a71a3a84329db284