### PR TITLE
docs: annotate ssh setup with idempotency checks

### DIFF
--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -138,10 +138,12 @@ DEPLOY_KEY="$PROJECT_ROOT/config/deploy_key"
 ##############################################################################
 
 # TODO: Idempotency: State detection
+# [ -d /root/.ssh ] || mkdir -p /root/.ssh
 # TODO: Idempotency: rollback handling and dry-run mode
 # run_cmd "mkdir -p /root/.ssh" "rmdir /root/.ssh"
 mkdir -p /root/.ssh
 # TODO: Idempotency: State detection
+# [ -f /root/.ssh/id_ed25519 ] || cp "$DEPLOY_KEY" /root/.ssh/id_ed25519
 # TODO: Idempotency: rollback handling and dry-run mode
 # run_cmd "cp \"$DEPLOY_KEY\" /root/.ssh/id_ed25519" "rm -f /root/.ssh/id_ed25519"
 cp "$DEPLOY_KEY" /root/.ssh/id_ed25519


### PR DESCRIPTION
## Summary
- illustrate idempotent state checks for SSH setup in GitHub module

## Testing
- `sh modules/github/test.sh` (fails: deploy key and repo not present)

------
https://chatgpt.com/codex/tasks/task_e_68902a4d9ee0832785773ef150843f03