### PR TITLE
docs: add example state check for repo clone

### DIFF
--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -174,6 +174,7 @@ ssh-keyscan github.com >> /root/.ssh/known_hosts
 ##############################################################################
 
 # TODO: Idempotency: State detection
+# [ -d "$LOCAL_DIR/.git" ] || git clone "$GITHUB_REPO" "$LOCAL_DIR"  # example for TODO above
 # TODO: Idempotency: rollback handling and dry-run mode
 # run_cmd "git clone \"$GITHUB_REPO\" \"$LOCAL_DIR\"" "rm -rf \"$LOCAL_DIR\""
 git clone "$GITHUB_REPO" "$LOCAL_DIR"


### PR DESCRIPTION
## Summary
- add commented example showing how to skip cloning if repo already exists

## Testing
- `sh modules/github/test.sh` (fails: deploy key and repo missing)
- `sh test-all.sh` (fails: missing system config, deploy key, users, repos)


------
https://chatgpt.com/codex/tasks/task_e_68902a4fdc0883279d693f21f39b8f53