### PR TITLE
Make GitHub module public key optional

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -48,7 +48,7 @@ LOCAL_DIR=/home/admin/example
 GITHUB_REPO=git@github.com:example/example.git
 # SSH key for GitHub module
 GITHUB_SSH_PRIVATE_KEY_FILE=github_id_ed25519
-GITHUB_SSH_PUBLIC_KEY_FILE=github_id_ed25519.pub
+# GITHUB_SSH_PUBLIC_KEY_FILE=github_id_ed25519.pub  # optional
 
 #=============================================================================
 # Additional modules can append their variables and SSH key settings below.

--- a/modules/github/README.md
+++ b/modules/github/README.md
@@ -6,7 +6,8 @@ Installs SSH keys for GitHub and clones a remote repository for use with Obsidia
 ## Prerequisites
 - Run as root on OpenBSD 7.4+
 - `config/secrets.env` with required values
-- SSH key files referenced by `GITHUB_SSH_PRIVATE_KEY_FILE` and `GITHUB_SSH_PUBLIC_KEY_FILE` located in `config/`
+- SSH private key file referenced by `GITHUB_SSH_PRIVATE_KEY_FILE` located in `config/`
+- (Optional) Public key file referenced by `GITHUB_SSH_PUBLIC_KEY_FILE` located in `config/`
 
 ## Key variables
 | Variable | Description |
@@ -14,7 +15,7 @@ Installs SSH keys for GitHub and clones a remote repository for use with Obsidia
 | `LOCAL_DIR` | Destination path for the local clone |
 | `GITHUB_REPO` | GitHub repository URL |
 | `GITHUB_SSH_PRIVATE_KEY_FILE` | Private key filename in `config/` |
-| `GITHUB_SSH_PUBLIC_KEY_FILE` | Public key filename in `config/` |
+| `GITHUB_SSH_PUBLIC_KEY_FILE` | Public key filename in `config/` (optional) |
 
 ## Setup
 ```sh

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -120,7 +120,11 @@ run_test() {
 run_tests() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): starting github tests" >&2
-  echo "1..9"
+  total=7
+  if [ -n "$GITHUB_SSH_PUBLIC_KEY_FILE" ]; then
+    total=$((total + 2))
+  fi
+  echo "1..$total"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 4 SSH setup" >&2
   run_test "[ -d /root/.ssh ]"                                                  "root .ssh directory exists" \
@@ -129,10 +133,12 @@ run_tests() {
            "ls -l /root/.ssh/id_ed25519"
   run_test "stat -f '%Lp' /root/.ssh/id_ed25519 | grep -q '^600$'"               "private key mode is 600" \
            "stat -f '%Sp' /root/.ssh/id_ed25519"
-  run_test "[ -f /root/.ssh/id_ed25519.pub ]"                                    "public key present" \
-           "ls -l /root/.ssh/id_ed25519.pub"
-  run_test "stat -f '%Lp' /root/.ssh/id_ed25519.pub | grep -q '^644$'"           "public key mode is 644" \
-           "stat -f '%Sp' /root/.ssh/id_ed25519.pub"
+  if [ -n "$GITHUB_SSH_PUBLIC_KEY_FILE" ]; then
+    run_test "[ -f /root/.ssh/id_ed25519.pub ]"                                    "public key present" \
+             "ls -l /root/.ssh/id_ed25519.pub"
+    run_test "stat -f '%Lp' /root/.ssh/id_ed25519.pub | grep -q '^644$'"           "public key mode is 644" \
+             "stat -f '%Sp' /root/.ssh/id_ed25519.pub"
+  fi
   run_test "[ -f /root/.ssh/known_hosts ]"                                       "known_hosts exists" \
            "ls -l /root/.ssh/known_hosts"
   run_test "grep -q '^github\\.com ' /root/.ssh/known_hosts"                     "known_hosts contains GitHub" \


### PR DESCRIPTION
## Summary
- allow modules/github/setup.sh to copy the public key only when `GITHUB_SSH_PUBLIC_KEY_FILE` is set
- skip public-key checks in modules/github/test.sh unless the variable is provided
- document that only `GITHUB_SSH_PRIVATE_KEY_FILE` is required and the public key is optional

## Testing
- `sh modules/github/test.sh` *(fails: missing keys and repo)*


------
https://chatgpt.com/codex/tasks/task_e_689136adefec8327a7f524d25ddcc6f5