### PR TITLE
Remove base system private key references

### DIFF
--- a/config/load-secrets.sh
+++ b/config/load-secrets.sh
@@ -13,7 +13,7 @@
 #   so the caller can prompt the user to edit it.
 #
 # Deployment considerations:
-#   Handling secrets and private keys is more difficult when cloning the repo
+#   Handling secrets is more difficult when cloning the repo
 #   directly onto a freshly installed server instead of preparing it offline
 #   and mounting via USB. Some assumptions (like pre-editing secrets.env) may
 #   break in unattended remote install workflows.

--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -16,20 +16,16 @@ DNS1=1.1.1.1
 DNS2=9.9.9.9
 ADMIN_USER=admin
 
-# --- Shared SSH keys per client device (root + admin) -----------------------
-# Add one block per device. Key files should live in this directory.
+# --- Shared SSH public keys per client device (root + admin) ----------------
+# Add one block per device. Public key files should live in this directory.
 # Example:
-DESKTOP_SSH_PRIVATE_KEY_FILE=id_ed25519_desktop
 DESKTOP_SSH_PUBLIC_KEY_FILE=id_ed25519_desktop.pub
-# LAPTOP_SSH_PRIVATE_KEY_FILE=id_ed25519_laptop
 # LAPTOP_SSH_PUBLIC_KEY_FILE=id_ed25519_laptop.pub
 # ---------------------------------------------------------------------------
 
-# --- Optional: separate keys for admin/root accounts ------------------------
+# --- Optional: separate public keys for admin/root accounts -----------------
 # Uncomment if you prefer distinct keys instead of the shared device keys.
-# ADMIN_SSH_PRIVATE_KEY_FILE=admin_id_ed25519
 # ADMIN_SSH_PUBLIC_KEY_FILE=admin_id_ed25519.pub
-# ROOT_SSH_PRIVATE_KEY_FILE=root_id_ed25519
 # ROOT_SSH_PUBLIC_KEY_FILES="root_id_ed25519.pub another_root_key.pub"
 #   # Space-separated list of public key files to grant root SSH access
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- drop private SSH key variables from base system example configuration
- clean up load-secrets documentation that mentioned private keys

## Testing
- `sh test-all.sh base-system` *(fails: authorized_keys missing)*

------
https://chatgpt.com/codex/tasks/task_e_689137934b488327a9094afb95d46da5