### PR TITLE
Remove optional GitHub public key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All notable changes to this project will be documented in this file following [K
 
 ### GitHub Module
 
-* GitHub module now reads SSH key filenames from `secrets.env` (`GITHUB_SSH_PRIVATE_KEY_FILE` and `GITHUB_SSH_PUBLIC_KEY_FILE`) instead of using a hardcoded deploy key.
+* GitHub module now reads the SSH private key filename from `secrets.env` (`GITHUB_SSH_PRIVATE_KEY_FILE`) instead of using a hardcoded deploy key.
+* Dropped support for the optional `GITHUB_SSH_PUBLIC_KEY_FILE`; the module now configures only the required private key.
 
 ## v1.0 – Initial Stable Release (2025-07-26)
 

--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -46,9 +46,8 @@ VAULT=vault
 #=============================================================================
 LOCAL_DIR=/home/admin/example
 GITHUB_REPO=git@github.com:example/example.git
-# SSH key for GitHub module
+# SSH private key for GitHub module
 GITHUB_SSH_PRIVATE_KEY_FILE=github_id_ed25519
-# GITHUB_SSH_PUBLIC_KEY_FILE=github_id_ed25519.pub  # optional
 
 #=============================================================================
 # Additional modules can append their variables and SSH key settings below.

--- a/modules/github/README.md
+++ b/modules/github/README.md
@@ -1,13 +1,12 @@
 # github
 
 ## Purpose
-Installs SSH keys for GitHub and clones a remote repository for use with Obsidian.
+Installs an SSH key for GitHub and clones a remote repository for use with Obsidian.
 
 ## Prerequisites
 - Run as root on OpenBSD 7.4+
 - `config/secrets.env` with required values
 - SSH private key file referenced by `GITHUB_SSH_PRIVATE_KEY_FILE` located in `config/`
-- (Optional) Public key file referenced by `GITHUB_SSH_PUBLIC_KEY_FILE` located in `config/`
 
 ## Key variables
 | Variable | Description |
@@ -15,7 +14,6 @@ Installs SSH keys for GitHub and clones a remote repository for use with Obsidia
 | `LOCAL_DIR` | Destination path for the local clone |
 | `GITHUB_REPO` | GitHub repository URL |
 | `GITHUB_SSH_PRIVATE_KEY_FILE` | Private key filename in `config/` |
-| `GITHUB_SSH_PUBLIC_KEY_FILE` | Public key filename in `config/` (optional) |
 
 ## Setup
 ```sh

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -17,7 +17,6 @@
 #     • LOCAL_DIR                    — target clone path
 #     • GITHUB_REPO                  — git@github.com:… or https://… URL
 #     • GITHUB_SSH_PRIVATE_KEY_FILE — filename of private key in config/
-#     • (Optional) GITHUB_SSH_PUBLIC_KEY_FILE  — filename of public key in config/
 #
 # Security note:
 #   Enabling the --debug flag will log all executed commands *and their expanded
@@ -137,11 +136,6 @@ CONFIG_DIR="$PROJECT_ROOT/config"
 PRIVATE_KEY_SRC="$CONFIG_DIR/$GITHUB_SSH_PRIVATE_KEY_FILE"
 [ -f "$PRIVATE_KEY_SRC" ] || { echo "ERROR: private key not found at $PRIVATE_KEY_SRC" >&2; exit 1; }
 
-if [ -n "$GITHUB_SSH_PUBLIC_KEY_FILE" ]; then
-  PUBLIC_KEY_SRC="$CONFIG_DIR/$GITHUB_SSH_PUBLIC_KEY_FILE"
-  [ -f "$PUBLIC_KEY_SRC" ] || { echo "ERROR: public key not found at $PUBLIC_KEY_SRC" >&2; exit 1; }
-fi
-
 ##############################################################################
 # 4) SSH setup (keys & known_hosts)
 ##############################################################################
@@ -163,18 +157,6 @@ cp "$PRIVATE_KEY_SRC" /root/.ssh/id_ed25519
 # run_cmd "chmod 600 /root/.ssh/id_ed25519" "chmod 000 /root/.ssh/id_ed25519"
 chmod 600 /root/.ssh/id_ed25519
 
-# Idempotency: state detection example
-# [ -f /root/.ssh/id_ed25519.pub ] || cp "$PUBLIC_KEY_SRC" /root/.ssh/id_ed25519.pub
-
-# Idempotency: rollback handling and dry-run mode example
-# run_cmd "cp \"$PUBLIC_KEY_SRC\" /root/.ssh/id_ed25519.pub" "rm -f /root/.ssh/id_ed25519.pub"
-if [ -n "$GITHUB_SSH_PUBLIC_KEY_FILE" ]; then
-  cp "$PUBLIC_KEY_SRC" /root/.ssh/id_ed25519.pub
-
-  # Idempotency: rollback handling and dry-run mode example
-  # run_cmd "chmod 644 /root/.ssh/id_ed25519.pub" "chmod 000 /root/.ssh/id_ed25519.pub"
-  chmod 644 /root/.ssh/id_ed25519.pub
-fi
 
 # TODO: Idempotency: state detection
 

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -121,9 +121,6 @@ run_tests() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): starting github tests" >&2
   total=7
-  if [ -n "$GITHUB_SSH_PUBLIC_KEY_FILE" ]; then
-    total=$((total + 2))
-  fi
   echo "1..$total"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 4 SSH setup" >&2
@@ -133,12 +130,6 @@ run_tests() {
            "ls -l /root/.ssh/id_ed25519"
   run_test "stat -f '%Lp' /root/.ssh/id_ed25519 | grep -q '^600$'"               "private key mode is 600" \
            "stat -f '%Sp' /root/.ssh/id_ed25519"
-  if [ -n "$GITHUB_SSH_PUBLIC_KEY_FILE" ]; then
-    run_test "[ -f /root/.ssh/id_ed25519.pub ]"                                    "public key present" \
-             "ls -l /root/.ssh/id_ed25519.pub"
-    run_test "stat -f '%Lp' /root/.ssh/id_ed25519.pub | grep -q '^644$'"           "public key mode is 644" \
-             "stat -f '%Sp' /root/.ssh/id_ed25519.pub"
-  fi
   run_test "[ -f /root/.ssh/known_hosts ]"                                       "known_hosts exists" \
            "ls -l /root/.ssh/known_hosts"
   run_test "grep -q '^github\\.com ' /root/.ssh/known_hosts"                     "known_hosts contains GitHub" \


### PR DESCRIPTION
## Summary
- streamline GitHub module to use only a required private SSH key
- document and config updates reflecting removal of optional public key
- note removal in changelog

## Testing
- `sh modules/github/test.sh` *(fails: private key, known_hosts, repo setup missing)*


------
https://chatgpt.com/codex/tasks/task_e_6891384034d48327a3e5ae50007f391f