### PR TITLE
Remove root SSH key handling from base-system module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ All notable changes to this project will be documented in this file following [K
 
 ### Base System Setup
 
-* Root account `authorized_keys` now populated from `ROOT_SSH_PUBLIC_KEY_FILES`,
-  enabling multiple keys to be provisioned during setup.
+* Removed management of root account `authorized_keys`; base-system no longer
+  populates root SSH keys during setup.
 
 ### GitHub Module
 

--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -16,18 +16,11 @@ DNS1=1.1.1.1
 DNS2=9.9.9.9
 ADMIN_USER=admin
 
-# --- Shared SSH public keys per client device (root + admin) ----------------
+# --- Shared SSH public keys per client device -------------------------------
 # Add one block per device. Public key files should live in this directory.
 # Example:
 DESKTOP_SSH_PUBLIC_KEY_FILE=id_ed25519_desktop.pub
 # LAPTOP_SSH_PUBLIC_KEY_FILE=id_ed25519_laptop.pub
-# ---------------------------------------------------------------------------
-
-# --- Optional: separate public keys for admin/root accounts -----------------
-# Uncomment if you prefer distinct keys instead of the shared device keys.
-# ADMIN_SSH_PUBLIC_KEY_FILE=admin_id_ed25519.pub
-# ROOT_SSH_PUBLIC_KEY_FILES="root_id_ed25519.pub another_root_key.pub"
-#   # Space-separated list of public key files to grant root SSH access
 # ---------------------------------------------------------------------------
 
 #=============================================================================

--- a/modules/base-system/README.md
+++ b/modules/base-system/README.md
@@ -1,7 +1,7 @@
 # base-system
 
 ## Purpose
-Configures hostname, networking, SSH hardening, root SSH authorized keys, and root shell history on a fresh OpenBSD server.
+Configures hostname, networking, SSH hardening, and root shell history on a fresh OpenBSD server.
 
 ## Prerequisites
 - Run as root on OpenBSD 7.4+
@@ -15,7 +15,6 @@ Configures hostname, networking, SSH hardening, root SSH authorized keys, and ro
 | `NETMASK` | Network mask |
 | `GATEWAY` | Default gateway |
 | `DNS1`, `DNS2` | Resolver addresses |
-| `ROOT_SSH_PUBLIC_KEY_FILES` | Space-separated list of root SSH public key filenames |
 
 ## Setup
 ```sh

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -232,37 +232,7 @@ sed -i 's/^#*PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd
 rcctl restart sshd
 
 ##############################################################################
-# 7) Root SSH authorized keys
-##############################################################################
-
-# TODO: Idempotency: state detection
-
-ROOT_KEYS="${ROOT_SSH_PUBLIC_KEY_FILES:-$ROOT_SSH_PUBLIC_KEY_FILE}"
-if [ -n "$ROOT_KEYS" ]; then
-  SRC_DIR="$PROJECT_ROOT/config"
-  SSH_DIR="/root/.ssh"
-  # Idempotency: rollback handling and dry-run mode example
-  # run_cmd "mkdir -p $SSH_DIR" "rmdir $SSH_DIR"
-  mkdir -p "$SSH_DIR"
-  # Idempotency: rollback handling and dry-run mode example
-  # run_cmd "chmod 700 $SSH_DIR" "chmod 755 $SSH_DIR"
-  chmod 700 "$SSH_DIR"
-  AUTH_FILE="$SSH_DIR/authorized_keys"
-  : > "$AUTH_FILE"
-  for key in $ROOT_KEYS; do
-    if [ -f "$SRC_DIR/$key" ]; then
-      cat "$SRC_DIR/$key" >> "$AUTH_FILE"
-    else
-      printf 'warning: root ssh key file "%s" not found in %s\n' "$key" "$SRC_DIR" >&2
-    fi
-  done
-  # Idempotency: rollback handling and dry-run mode example
-  # run_cmd "chmod 600 $AUTH_FILE" "chmod 644 $AUTH_FILE"
-  chmod 600 "$AUTH_FILE"
-fi
-
-##############################################################################
-# 8) Root history
+# 7) Root history
 ##############################################################################
 
 # TODO: Idempotency: use state detection

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -119,12 +119,7 @@ assert_file_perm() {
 run_tests() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): starting base-system tests" >&2
-  ROOT_KEYS="${ROOT_SSH_PUBLIC_KEY_FILES:-$ROOT_SSH_PUBLIC_KEY_FILE}"
-  key_count=0
-  for _k in $ROOT_KEYS; do
-    key_count=$((key_count + 1))
-  done
-  total_tests=$((15 + 4 + key_count))
+  total_tests=15
   echo "1..${total_tests}"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 4 networking config files" >&2
@@ -160,19 +155,7 @@ run_tests() {
   run_test "rcctl check sshd"                                                  "sshd service is running" \
            "ps -ax | grep '[s]shd'"
 
-  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7 root ssh keys" >&2
-  run_test "[ -d /root/.ssh ]"                                                ".ssh for root exists" \
-           "ls -ld /root/.ssh"
-  assert_file_perm "/root/.ssh" "700"                                         ".ssh perms for root"
-  run_test "[ -f /root/.ssh/authorized_keys ]"                                "authorized_keys for root exists" \
-           "ls -l /root/.ssh/authorized_keys"
-  assert_file_perm "/root/.ssh/authorized_keys" "600"                        "authorized_keys perms for root"
-  for k in $ROOT_KEYS; do
-    keydata="$(cat "$PROJECT_ROOT/config/$k" 2>/dev/null || true)"
-    run_test "grep -Fq \"$keydata\" /root/.ssh/authorized_keys"           "authorized_keys contains $k"
-  done
-
-  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 8 root history" >&2
+  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7 root history" >&2
   run_test "grep -q '^export HISTFILE=/root/.ksh_history' /root/.profile"      "root .profile sets HISTFILE" \
            "grep '^export HISTFILE' /root/.profile"
   run_test "grep -q '^export HISTSIZE=5000' /root/.profile"                    "root .profile sets HISTSIZE" \


### PR DESCRIPTION
## Summary
- stop populating root `authorized_keys` during base-system setup
- drop root SSH key checks from base-system tests
- update docs and config examples to remove root key variables

## Testing
- `sh modules/base-system/test.sh` *(fails: netstat, sshd_config, rcctl not found)*

------
https://chatgpt.com/codex/tasks/task_e_689154930db88327a78036093d21ca1c