### PR TITLE
Add doas configuration for admin user

### DIFF
--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -270,7 +270,21 @@ chmod 600 "$AUTH_KEYS"
 chown -R "$ADMIN_USER:$ADMIN_USER" "$SSH_DIR"
 
 ##############################################################################
-# 8) Root history
+# 8) Doas configuration
+##############################################################################
+
+DOAS_CONF="/etc/doas.conf"
+if [ -f "$DOAS_CONF" ]; then
+  grep -Fqx "permit persist ${ADMIN_USER} as root" "$DOAS_CONF" 2>/dev/null \
+    || echo "permit persist ${ADMIN_USER} as root" >> "$DOAS_CONF"
+else
+  echo "permit persist ${ADMIN_USER} as root" > "$DOAS_CONF"
+fi
+chown root:wheel "$DOAS_CONF"
+chmod 440 "$DOAS_CONF"
+
+##############################################################################
+# 9) Root history
 ##############################################################################
 
 # TODO: Idempotency: use state detection

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -119,7 +119,7 @@ assert_file_perm() {
 run_tests() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): starting base-system tests" >&2
-  total_tests=23
+  total_tests=26
   echo "1..${total_tests}"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 4 networking config files" >&2
@@ -175,7 +175,14 @@ run_tests() {
            "authorized_keys contains admin public key" \
            "cat /home/${ADMIN_USER}/.ssh/authorized_keys"
 
-  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 8 root history" >&2
+  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 8 doas configuration" >&2
+  run_test "grep -q '^permit persist ${ADMIN_USER} as root$' /etc/doas.conf"   "doas rule for ${ADMIN_USER}" \
+           "cat /etc/doas.conf"
+  run_test "stat -f '%Su:%Sg' /etc/doas.conf | grep -q '^root:wheel$'"         "doas.conf owner root:wheel" \
+           "stat -f '%Su:%Sg' /etc/doas.conf"
+  assert_file_perm "/etc/doas.conf" "440"                                     "doas.conf mode is 440"
+
+  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 9 root history" >&2
   run_test "grep -q '^export HISTFILE=/root/.ksh_history' /root/.profile"      "root .profile sets HISTFILE" \
            "grep '^export HISTFILE' /root/.profile"
   run_test "grep -q '^export HISTSIZE=5000' /root/.profile"                    "root .profile sets HISTSIZE" \


### PR DESCRIPTION
## Summary
- Configure setup to create `/etc/doas.conf` with an admin rule and strict ownership/permissions
- Extend tests to verify `doas.conf` rule, ownership, and mode

## Testing
- `sh modules/base-system/test.sh` *(fails: `grep: /etc/doas.conf: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6893b6b9b16c832792fbfc42ce072693