### PR TITLE
Lock admin account password

### DIFF
--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -243,8 +243,8 @@ if ! id "$ADMIN_USER" >/dev/null 2>&1; then
   # run_cmd "useradd -m -G wheel -s /bin/ksh $ADMIN_USER" "userdel $ADMIN_USER"
   useradd -m -G wheel -s /bin/ksh "$ADMIN_USER"
   # Idempotency: rollback handling and dry-run mode example
-  # run_cmd "usermod -p '' $ADMIN_USER" "passwd -l $ADMIN_USER"
-  usermod -p '' "$ADMIN_USER"
+  # run_cmd "usermod -p '*' $ADMIN_USER" "passwd -u $ADMIN_USER"
+  usermod -p '*' "$ADMIN_USER"
 fi
 
 CONFIG_DIR="$PROJECT_ROOT/config"

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -119,7 +119,7 @@ assert_file_perm() {
 run_tests() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): starting base-system tests" >&2
-  total_tests=31
+  total_tests=32
   echo "1..${total_tests}"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 4 networking config files" >&2
@@ -158,6 +158,8 @@ run_tests() {
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7 admin ssh access" >&2
   run_test "id ${ADMIN_USER} >/dev/null 2>&1"                                 "account ${ADMIN_USER} exists" \
            "id ${ADMIN_USER}"
+  run_test "grep -q '^${ADMIN_USER}:\\*:' /etc/master.passwd"                 "account ${ADMIN_USER} password locked" \
+           "grep '^${ADMIN_USER}:' /etc/master.passwd"
   run_test "[ -d /home/${ADMIN_USER}/.ssh ]"                                  "ssh dir for ${ADMIN_USER} exists" \
            "ls -ld /home/${ADMIN_USER}/.ssh"
   assert_file_perm "/home/${ADMIN_USER}/.ssh" "700"                           "ssh dir perms for ${ADMIN_USER}"


### PR DESCRIPTION
## Summary
- replace insecure blank-password usermod with locked password placeholder
- verify admin account password is locked in test suite

## Testing
- `sh modules/base-system/test.sh` *(fails: root .profile sets HISTCONTROL, admin .profile entries missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893baef07f4832792ebf80290eb401f