### PR TITLE
feat(base-system): allow admin password via secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file following [K
   keys specified in `secrets.env`.
 * Base-system now creates the `ADMIN_USER` account and installs its SSH public
   key(s).
+* Base-system can optionally set the `ADMIN_USER` password from `secrets.env`
+  when `ADMIN_PASSWORD` is provided.
 
 ### GitHub Module
 

--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -17,6 +17,8 @@ DNS2=9.9.9.9
 ADMIN_USER=admin
 # SSH public key filename for ADMIN_USER (stored in config/)
 ADMIN_SSH_PUBLIC_KEY_FILE=admin_id_ed25519.pub
+# Optional plaintext password for ADMIN_USER (leave empty to disable password login)
+ADMIN_PASSWORD=
 
 # --- Additional SSH public keys per client device (optional) ----------------
 # Add one block per device to authorize multiple clients for ADMIN_USER.

--- a/modules/base-system/README.md
+++ b/modules/base-system/README.md
@@ -17,6 +17,7 @@ Configures hostname, networking, SSH hardening, and root shell history on a fres
 | `DNS1`, `DNS2` | Resolver addresses |
 | `ADMIN_USER` | Admin account to create |
 | `ADMIN_SSH_PUBLIC_KEY_FILE` | SSH public key filename for `ADMIN_USER` (in `config/`) |
+| `ADMIN_PASSWORD` | Optional password for `ADMIN_USER`; if unset, password login is disabled |
 
 ## Setup
 ```sh

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -242,6 +242,15 @@ if ! id "$ADMIN_USER" >/dev/null 2>&1; then
   # Idempotency: rollback handling and dry-run mode example
   # run_cmd "useradd -m -G wheel -s /bin/ksh $ADMIN_USER" "userdel $ADMIN_USER"
   useradd -m -G wheel -s /bin/ksh "$ADMIN_USER"
+fi
+
+# Set admin password if provided; otherwise lock the account
+if [ -n "$ADMIN_PASSWORD" ]; then
+  pw_hash="$(encrypt -b "$ADMIN_PASSWORD")"
+  # Idempotency: rollback handling and dry-run mode example
+  # run_cmd "usermod -p '$pw_hash' $ADMIN_USER" "passwd -u $ADMIN_USER"
+  usermod -p "$pw_hash" "$ADMIN_USER"
+else
   # Idempotency: rollback handling and dry-run mode example
   # run_cmd "usermod -p '*' $ADMIN_USER" "passwd -u $ADMIN_USER"
   usermod -p '*' "$ADMIN_USER"

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -158,8 +158,13 @@ run_tests() {
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7 admin ssh access" >&2
   run_test "id ${ADMIN_USER} >/dev/null 2>&1"                                 "account ${ADMIN_USER} exists" \
            "id ${ADMIN_USER}"
-  run_test "grep -q '^${ADMIN_USER}:\\*:' /etc/master.passwd"                 "account ${ADMIN_USER} password locked" \
-           "grep '^${ADMIN_USER}:' /etc/master.passwd"
+  if [ -n "${ADMIN_PASSWORD}" ]; then
+    run_test "grep -q '^${ADMIN_USER}:[^*]' /etc/master.passwd"                "account ${ADMIN_USER} password set" \
+             "grep '^${ADMIN_USER}:' /etc/master.passwd"
+  else
+    run_test "grep -q '^${ADMIN_USER}:\\*:' /etc/master.passwd"               "account ${ADMIN_USER} password locked" \
+             "grep '^${ADMIN_USER}:' /etc/master.passwd"
+  fi
   run_test "[ -d /home/${ADMIN_USER}/.ssh ]"                                  "ssh dir for ${ADMIN_USER} exists" \
            "ls -ld /home/${ADMIN_USER}/.ssh"
   assert_file_perm "/home/${ADMIN_USER}/.ssh" "700"                           "ssh dir perms for ${ADMIN_USER}"


### PR DESCRIPTION
## Summary
- support optional `ADMIN_PASSWORD` for the admin account
- document admin password option in base-system module

## Testing
- `sh modules/base-system/test.sh` *(fails: missing OpenBSD environment)*

------
https://chatgpt.com/codex/tasks/task_e_6893bc894500832785882ffa7094e505