### PR TITLE
Restart sshd after adding AllowUsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file following [K
   key(s).
 * Base-system can optionally set the `ADMIN_USER` password from `secrets.env`
   when `ADMIN_PASSWORD` is provided.
+* Restart `sshd` after adding the admin account to `AllowUsers` so configuration
+  changes take effect immediately.
 
 ### GitHub Module
 

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -227,9 +227,6 @@ sed -i 's/^#*PermitRootLogin .*/PermitRootLogin no/' /etc/ssh/sshd_config
 # Idempotency: safe editing example
 # safe_replace_line /etc/ssh/sshd_config '^#*PasswordAuthentication .*' 'PasswordAuthentication no'
 sed -i 's/^#*PasswordAuthentication .*/PasswordAuthentication no/' /etc/ssh/sshd_config
-# Idempotency: rollback handling and dry-run mode example
-# run_cmd "rcctl restart sshd" "rcctl restart sshd"
-rcctl restart sshd
 
 ##############################################################################
 # 7) Admin user & SSH access
@@ -278,6 +275,7 @@ done
 echo "AllowUsers ${ADMIN_USER}" >> /etc/ssh/sshd_config
 chmod 600 "$AUTH_KEYS"
 chown -R "$ADMIN_USER:$ADMIN_USER" "$SSH_DIR"
+rcctl restart sshd
 
 ##############################################################################
 # 8) Doas configuration


### PR DESCRIPTION
## Summary
- restart `sshd` after appending admin account to `AllowUsers` so directive takes effect immediately
- document the restart in the changelog

## Testing
- `sh test-all.sh base-system` *(fails: admin .profile not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d0f69f4483279f792b94231c2cf1