### PR TITLE
Add helper to merge sshd AllowUsers list

### DIFF
--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -178,8 +178,8 @@ run_tests() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7.1 SSH service & config" >&2
 
-  run_test "grep -q \"^AllowUsers ${OBS_USER} ${GIT_USER}\$\" /etc/ssh/sshd_config" \
-           "sshd_config has AllowUsers" \
+  run_test "awk '/^AllowUsers/{for(i=2;i<=NF;i++)u[\\$i]=1} END{exit !(u[\"${ADMIN_USER}\"] && u[\"${OBS_USER}\"] && u[\"${GIT_USER}\"])}' /etc/ssh/sshd_config" \
+           "sshd_config allows ${ADMIN_USER}, ${OBS_USER}, ${GIT_USER}" \
            "grep '^AllowUsers' /etc/ssh/sshd_config"
   run_test "pgrep -x sshd >/dev/null"                                       "sshd daemon running" \
            "pgrep -ax sshd || true"


### PR DESCRIPTION
## Summary
- Add `safe_replace_line` helper to merge directive entries without duplicating users
- Use helper in base-system to add `ADMIN_USER` only when missing
- Include `ADMIN_USER` with `OBS_USER` and `GIT_USER` for sshd's `AllowUsers` and test it

## Testing
- `sh modules/base-system/test.sh` (fails: admin profile & history checks)
- `sh modules/obsidian-git-host/test.sh` (fails: no output)


------
https://chatgpt.com/codex/tasks/task_e_689532d1431c8327a76680b153ecc2fc