### PR TITLE
Fix obsidian git host test

### DIFF
--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -182,11 +182,11 @@ check_entry() {
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7.1 SSH service & config" >&2
 
-  run_test "awk '/^AllowUsers/{for(i=2;i<=NF;i++)u[\\$i]=1} END{exit !(u[\"${ADMIN_USER}\"] && u[\"${OBS_USER}\"] && u[\"${GIT_USER}\"])}' /etc/ssh/sshd_config" \
+  run_test "allow_line=\$(grep '^AllowUsers' /etc/ssh/sshd_config); echo \"\$allow_line\" | grep -qw ${ADMIN_USER} && echo \"\$allow_line\" | grep -qw ${OBS_USER} && echo \"\$allow_line\" | grep -qw ${GIT_USER}" \
            "sshd_config allows ${ADMIN_USER}, ${OBS_USER}, ${GIT_USER}" \
            "grep '^AllowUsers' /etc/ssh/sshd_config"
   run_test "pgrep -x sshd >/dev/null"                                       "sshd daemon running" \
-           "pgrep -ax sshd || true"
+           "pgrep -x sshd || true"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 7.2 .ssh directories" >&2
 


### PR DESCRIPTION
## Summary
- fix quoting issue in sshd_config AllowUsers test
- use supported options in sshd process check

## Testing
- `sh modules/obsidian-git-host/test.sh --log` *(fails: No section for '--log' found in '/workspace/openbsd-toolkit/config/secrets.env')*

------
https://chatgpt.com/codex/tasks/task_e_6895f1d167088327981ff685ad6b17d9