### PR TITLE
Make admin doas rule passwordless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file following [K
   when `ADMIN_PASSWORD` is provided.
 * Restart `sshd` after adding the admin account to `AllowUsers` so configuration
   changes take effect immediately.
+* Configured `doas` to allow the `ADMIN_USER` account to run commands as root without a password.
 
 ### GitHub Module
 

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -299,7 +299,7 @@ rcctl restart sshd
 
 DOAS_CONF="/etc/doas.conf"
 # TODO: Idempotency: implement checks to avoid duplicate entries
-echo "permit persist ${ADMIN_USER} as root" >> "$DOAS_CONF"
+echo "permit nopass ${ADMIN_USER} as root" >> "$DOAS_CONF"
 chown root:wheel "$DOAS_CONF"
 chmod 440 "$DOAS_CONF"
 

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -183,7 +183,7 @@ run_tests() {
            "cat /home/${ADMIN_USER}/.ssh/authorized_keys"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 8 doas configuration" >&2
-  run_test "grep -q '^permit persist ${ADMIN_USER} as root$' /etc/doas.conf"   "doas rule for ${ADMIN_USER}" \
+  run_test "grep -q '^permit nopass ${ADMIN_USER} as root$' /etc/doas.conf"   "doas rule for ${ADMIN_USER}" \
            "cat /etc/doas.conf"
   run_test "stat -f '%Su:%Sg' /etc/doas.conf | grep -q '^root:wheel$'"         "doas.conf owner root:wheel" \
            "stat -f '%Su:%Sg' /etc/doas.conf"

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -163,9 +163,9 @@ check_entry() {
 
     run_test "[ -f /etc/doas.conf ]"                                          "doas.conf exists" \
            "ls -l /etc/doas.conf"
-    run_test "grep -q \"^permit persist ${ADMIN_USER} as root\$\" /etc/doas.conf" \
+    run_test "grep -q \"^permit nopass ${ADMIN_USER} as root\$\" /etc/doas.conf" \
             "doas.conf retains admin rule for ${ADMIN_USER}" \
-            "grep '^permit persist' /etc/doas.conf"
+            "grep '^permit nopass' /etc/doas.conf"
     run_test "grep -q \"^permit persist ${OBS_USER} as root\$\" /etc/doas.conf" \
             "doas.conf allows persist ${OBS_USER}" \
             "grep '\^permit' /etc/doas.conf"


### PR DESCRIPTION
## Summary
- Allow the admin account to run doas commands without a password
- Update tests to expect the admin nopass rule
- Document the change in the changelog

## Testing
- `sh test-all.sh` *(fails: stat cannot read file system information for '%Lp')*

------
https://chatgpt.com/codex/tasks/task_e_6896b7f93f188327b2e6d3c0391ac198