### PR TITLE
Bump script versions to 1.0.1

### DIFF
--- a/config/load-secrets.sh
+++ b/config/load-secrets.sh
@@ -2,7 +2,7 @@
 #
 # config/load-secrets.sh — Export variables from secrets.env for other scripts
 # Author: deadhedd
-# Version: 1.1.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: . "$PROJECT_ROOT/config/load-secrets.sh" <ModuleName>   # must be sourced

--- a/install-modules.sh
+++ b/install-modules.sh
@@ -2,7 +2,7 @@
 #
 # install-modules.sh — Install specified modules, or all in enabled_modules.conf
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh install-modules.sh [--debug[=FILE]] [-h] [module1 module2 ...]

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -2,7 +2,7 @@
 #
 # logs/logging.sh — Centralized logging & debug helpers (sourced utility)
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage:

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -2,7 +2,7 @@
 #
 # modules/base-system/setup.sh — General system configuration for OpenBSD server
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-05
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -2,7 +2,7 @@
 #
 # modules/base-system/test.sh — Verify base-system configuration (networking, SSH, history)
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-05
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -2,7 +2,7 @@
 #
 # modules/github/setup.sh — Configure GitHub SSH key & bootstrap local repo
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -2,7 +2,7 @@
 #
 # modules/github/test.sh — Verify GitHub SSH key & repo bootstrap
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -2,7 +2,7 @@
 #
 # modules/obsidian-git-client/test.sh — Verify client-side Obsidian Git sync
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # modules/obsidian-git-host/setup.sh — Git-backed Obsidian vault setup
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -2,7 +2,7 @@
 #
 # modules/obsidian-git-host/test.sh — Verify Obsidian vault sync configuration
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]

--- a/test-all.sh
+++ b/test-all.sh
@@ -2,7 +2,7 @@
 #
 # test-all.sh — Run tests for specified modules, enabled_modules.conf, or all modules
 # Author: deadhedd
-# Version: 1.0.0
+# Version: 1.0.1
 # Updated: 2025-08-02
 #
 # Usage: sh test-all.sh [--log[=FILE]] [--debug[=FILE]] [-h] [module1 module2 ...]


### PR DESCRIPTION
## Summary
- standardize version headers in all scripts to 1.0.1

## Testing
- `sh test-all.sh` *(fails: missing expected files and configuration for modules)*

------
https://chatgpt.com/codex/tasks/task_e_6897ea4db6f08327aa5e635c0c0751f0