### PR TITLE
Use CLIENT_VAULT for obsidian git client test vault path

### DIFF
--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -67,8 +67,9 @@ start_logging "$SCRIPT_PATH" "$@"
 
 . "$PROJECT_ROOT/config/load-secrets.sh" "Base System"
 . "$PROJECT_ROOT/config/load-secrets.sh" "Obsidian Git Host"
+. "$PROJECT_ROOT/config/load-secrets.sh" "Obsidian Git Client"
 
-LOCAL_VAULT="$HOME/${VAULT}"
+LOCAL_VAULT="$HOME/${CLIENT_VAULT}"
 
 ##############################################################################
 # 4) Test helpers


### PR DESCRIPTION
## Summary
- Load `CLIENT_VAULT` secrets in obsidian-git-client test
- Use `CLIENT_VAULT` to resolve the local vault path

## Testing
- `sh modules/obsidian-git-client/test.sh` *(fails: missing Obsidian Git setup)*


------
https://chatgpt.com/codex/tasks/task_e_68992cf33ee08327afd25d7fc049ea80