### PR TITLE
feat: restore OBS_USER ssh setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file following [K
   * Removed optional public key file support and "deploy key" terminology.
 * **Obsidian Modules**:
   * *Git Client*: README and tests simplified to only verify the local vault Git repo.
-  * *Git Host*: Setup supports service accounts without SSH; tests reduced from 58 to 43 in line with admin-only SSH policy.
+  * *Git Host*: Restores `.ssh` setup for `OBS_USER` while keeping `GIT_USER` without SSH; tests expanded from 43 to 54.
 
 ### Documentation
 


### PR DESCRIPTION
## Summary
- provision `.ssh` directory, authorized keys, and known hosts for `OBS_USER`
- ensure `GIT_USER` has no SSH access
- expand tests and changelog for restored `OBS_USER` SSH items

## Testing
- `shellcheck modules/obsidian-git-host/setup.sh` *(fails: command not found)*
- `shellcheck modules/obsidian-git-host/test.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `sh modules/obsidian-git-host/test.sh` *(fails: Created '/workspace/openbsd-toolkit/config/secrets.env' from example. Please edit it and re-run.)*


------
https://chatgpt.com/codex/tasks/task_e_689a028287248327bdebed1487c942e7