### PR TITLE
docs: document GIT_SERVER requirement

### DIFF
--- a/modules/obsidian-git-host/README.md
+++ b/modules/obsidian-git-host/README.md
@@ -13,6 +13,7 @@ Creates users and a shared bare Git repository so multiple accounts can sync an 
 | `OBS_USER` | Local Obsidian user |
 | `GIT_USER` | Service account used for pushes |
 | `VAULT` | Vault name used for repository paths |
+| `GIT_SERVER` | Hostname or IP used for SSH known_hosts |
 
 ## Setup
 ```sh


### PR DESCRIPTION
## Summary
- note that `GIT_SERVER` must be set for `obsidian-git-host` (SSH known_hosts)

## Testing
- `sh modules/obsidian-git-host/test.sh` *(fails: Created 'config/secrets.env' from example. Please edit it and re-run.)*


------
https://chatgpt.com/codex/tasks/task_e_689f55809b988327a7b4d277f860aab1