### PR TITLE
chore: bump scripts to v1.0.2

### DIFF
--- a/config/load-secrets.sh
+++ b/config/load-secrets.sh
@@ -2,8 +2,8 @@
 #
 # config/load-secrets.sh — Export variables from secrets.env for other scripts
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: . "$PROJECT_ROOT/config/load-secrets.sh" <ModuleName>   # must be sourced
 #

--- a/install-modules.sh
+++ b/install-modules.sh
@@ -2,8 +2,8 @@
 #
 # install-modules.sh — Install specified modules, or all in enabled_modules.conf
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: sh install-modules.sh [--debug[=FILE]] [-h] [module1 module2 ...]
 #

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -3,7 +3,7 @@
 # logs/logging.sh — Centralized logging & debug helpers (sourced utility)
 # Author: deadhedd
 # Version: 1.0.2
-# Updated: 2025-08-10
+# Updated: 2025-08-22
 #
 # Usage:
 #   . "$PROJECT_ROOT/logs/logging.sh"

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -2,8 +2,8 @@
 #
 # modules/base-system/setup.sh — General system configuration for OpenBSD server
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]
 #

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -2,8 +2,8 @@
 #
 # modules/base-system/test.sh — Verify base-system configuration (networking, SSH, history)
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -2,8 +2,8 @@
 #
 # modules/github/setup.sh — Configure GitHub SSH key & bootstrap local repo
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]
 #

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -2,8 +2,8 @@
 #
 # modules/github/test.sh — Verify GitHub SSH key & repo bootstrap
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -3,7 +3,7 @@
 # modules/obsidian-git-client/test.sh — Verify client-side Obsidian Git sync
 # Author: deadhedd
 # Version: 1.0.2
-# Updated: 2025-08-11
+# Updated: 2025-08-22
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -2,7 +2,7 @@
 # modules/obsidian-git-host/setup.sh — Git-backed Obsidian vault setup
 # Author: deadhedd
 # Version: 1.0.2
-# Updated: 2025-08-10
+# Updated: 2025-08-22
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]
 #

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -3,7 +3,7 @@
 # modules/obsidian-git-host/test.sh — Verify Obsidian vault sync configuration
 # Author: deadhedd
 # Version: 1.0.2
-# Updated: 2025-08-10
+# Updated: 2025-08-22
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/test-all.sh
+++ b/test-all.sh
@@ -2,8 +2,8 @@
 #
 # test-all.sh — Run tests for specified modules, enabled_modules.conf, or all modules
 # Author: deadhedd
-# Version: 1.0.1
-# Updated: 2025-08-10
+# Version: 1.0.2
+# Updated: 2025-08-22
 #
 # Usage: sh test-all.sh [--log[=FILE]] [--debug[=FILE]] [-h] [module1 module2 ...]
 #


### PR DESCRIPTION
## Summary
- standardize all shell scripts to version 1.0.2
- update script headers with today's date

## Testing
- `sh test-all.sh` *(fails: OBS_USER must be set in secrets; module tests failed)*
- `shellcheck config/load-secrets.sh install-modules.sh logs/logging.sh modules/base-system/setup.sh modules/base-system/test.sh modules/github/setup.sh modules/github/test.sh modules/obsidian-git-client/test.sh modules/obsidian-git-host/setup.sh modules/obsidian-git-host/test.sh test-all.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a867d16de48327a477ace92581b24c