### PR TITLE
Handle new secrets file format

### DIFF
--- a/modules/base-system/README.md
+++ b/modules/base-system/README.md
@@ -16,7 +16,7 @@ Configures hostname, networking, SSH hardening, and root shell history on a fres
 | `GATEWAY` | Default gateway |
 | `DNS1`, `DNS2` | Resolver addresses |
 | `ADMIN_USER` | Admin account to create |
-| `ADMIN_SSH_PUBLIC_KEY_FILE` | SSH public key filename for `ADMIN_USER` (in `config/`) |
+| `SSH_ADMIN_PUBLIC` | Admin's SSH public key filename (relative to `SSH_KEY_DIR`; uses `SSH_PUBLIC_KEY_DEFAULT` if blank) |
 | `ADMIN_PASSWORD` | Optional password for `ADMIN_USER`; if unset, password login is disabled |
 
 ## Setup

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -76,6 +76,7 @@ start_logging "$SCRIPT_PATH" "$@"
 ##############################################################################
 
 . "$PROJECT_ROOT/config/load-secrets.sh" "Base System"
+. "$PROJECT_ROOT/config/load-secrets.sh" "SSH"
 
 ##############################################################################
 # 4) Test helpers
@@ -177,10 +178,12 @@ run_tests() {
   run_test "stat -f '%Su:%Sg' /home/${ADMIN_USER}/.ssh/authorized_keys | grep -q '^${ADMIN_USER}:${ADMIN_USER}\$'" \
            "authorized_keys owner for ${ADMIN_USER}" \
            "stat -f '%Su:%Sg' /home/${ADMIN_USER}/.ssh/authorized_keys"
-  admin_pub_key=$(tr -d '\n' < "$PROJECT_ROOT/config/$ADMIN_SSH_PUBLIC_KEY_FILE")
-  run_test "grep -Fq '$admin_pub_key' /home/${ADMIN_USER}/.ssh/authorized_keys" \
-           "authorized_keys contains admin public key" \
-           "cat /home/${ADMIN_USER}/.ssh/authorized_keys"
+    key_dir="$PROJECT_ROOT/$SSH_KEY_DIR"
+    admin_key_file="${SSH_ADMIN_PUBLIC:-$SSH_PUBLIC_KEY_DEFAULT}"
+    admin_pub_key=$(tr -d '\n' < "$key_dir/$admin_key_file")
+    run_test "grep -Fq '$admin_pub_key' /home/${ADMIN_USER}/.ssh/authorized_keys" \
+            "authorized_keys contains admin public key" \
+            "cat /home/${ADMIN_USER}/.ssh/authorized_keys"
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 8 doas configuration" >&2
   run_test "grep -q '^permit nopass ${ADMIN_USER} as root$' /etc/doas.conf"   "doas rule for ${ADMIN_USER}" \

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -151,13 +151,14 @@ start_logging_if_debug "setup-$module_name" "$@"
 : "${VAULT:?VAULT must be set in secrets}"
 : "${GIT_SERVER:?GIT_SERVER must be set in secrets}"
 
-ADMIN_PUB_KEY_PATH="$PROJECT_ROOT/config/$ADMIN_SSH_PUBLIC_KEY_FILE"
-if [ -f "$ADMIN_PUB_KEY_PATH" ]; then
-  ADMIN_PUB_KEY="$(cat "$ADMIN_PUB_KEY_PATH")"
-else
-  echo "WARNING: missing admin SSH public key file $ADMIN_PUB_KEY_PATH" >&2
-  ADMIN_PUB_KEY=""
-fi
+# TODO: When SSH admin key handling is reintroduced, restore this block
+# ADMIN_PUB_KEY_PATH="$PROJECT_ROOT/config/$ADMIN_SSH_PUBLIC_KEY_FILE"
+# if [ -f "$ADMIN_PUB_KEY_PATH" ]; then
+#   ADMIN_PUB_KEY="$(cat "$ADMIN_PUB_KEY_PATH")"
+# else
+#   echo "WARNING: missing admin SSH public key file $ADMIN_PUB_KEY_PATH" >&2
+#   ADMIN_PUB_KEY=""
+# fi
 
 ##############################################################################
 # 4) Packages


### PR DESCRIPTION
## Summary
- Load Module: SSH in base-system scripts and derive admin keys from SSH_* variables
- Update base-system README to mention SSH_ADMIN_PUBLIC
- Comment out legacy admin key handling in obsidian-git-host setup for later reference

## Testing
- `sh -n modules/base-system/setup.sh modules/base-system/test.sh modules/obsidian-git-host/setup.sh`
- `sh modules/base-system/test.sh` *(fails: Created '/workspace/openbsd-toolkit/config/secrets.env' from example. Please edit it and re-run.)*
- `shellcheck modules/obsidian-git-host/setup.sh` *(command not found; apt-get update failed: "The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a64726408327b11a61151261b9a0