### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🛠️ OpenBSD Toolkit
 
-Modular shell scripts for automating system setup and tooling on OpenBSD, starting with a fully working Obsidian Git host. Built with security, maintainability, and automation in mind — with future plans to expand into general-purpose OpenBSD tools. This branch prepares for the v1.0.2 release, restoring `.ssh` setup for both `OBS_USER` and `GIT_USER`, improving logging with exit-code capture, and expanding the test suite to 59 checks. Refer to the [CHANGELOG](CHANGELOG.md) for details.
+Modular shell scripts for automating system setup and tooling on OpenBSD, starting with a fully working Obsidian Git host. Built with security, maintainability, and automation in mind — with future plans to expand into general-purpose OpenBSD tools. This branch prepares for the v1.0.3 release, restoring `.ssh` setup for both `OBS_USER` and `GIT_USER`, improving logging with exit-code capture, and expanding the test suite to 59 checks. Refer to the [CHANGELOG](CHANGELOG.md) for details.
 
 ---
 ## 🚀 Quick Start
@@ -49,7 +49,7 @@ This toolkit currently includes:
 * A Git bare repo module to host an Obsidian-compatible vault with auto-deploy
 * A minimal GitHub module for immediate push capability after setup
 
-The v1.0.2 update reinstates automatic `.ssh` configuration for both `OBS_USER` and `GIT_USER`, simplifying secure access.
+The v1.0.3 update reinstates automatic `.ssh` configuration for both `OBS_USER` and `GIT_USER`, simplifying secure access.
 
 All modules are modular and extensible. The long-term vision includes additional OpenBSD automation tools for broader system management.
 

--- a/config/load-secrets.sh
+++ b/config/load-secrets.sh
@@ -2,8 +2,8 @@
 #
 # config/load-secrets.sh — Export variables from secrets.env for other scripts
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: . "$PROJECT_ROOT/config/load-secrets.sh" <ModuleName>   # must be sourced
 #

--- a/install-modules.sh
+++ b/install-modules.sh
@@ -2,8 +2,8 @@
 #
 # install-modules.sh — Install specified modules, or all in enabled_modules.conf
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh install-modules.sh [--debug[=FILE]] [-h] [module1 module2 ...]
 #

--- a/logs/logging.sh
+++ b/logs/logging.sh
@@ -2,8 +2,8 @@
 #
 # logs/logging.sh — Centralized logging & debug helpers (sourced utility)
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage:
 #   . "$PROJECT_ROOT/logs/logging.sh"

--- a/modules/base-system/setup.sh
+++ b/modules/base-system/setup.sh
@@ -2,8 +2,8 @@
 #
 # modules/base-system/setup.sh — General system configuration for OpenBSD server
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]
 #

--- a/modules/base-system/test.sh
+++ b/modules/base-system/test.sh
@@ -2,8 +2,8 @@
 #
 # modules/base-system/test.sh — Verify base-system configuration (networking, SSH, history)
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/modules/github/setup.sh
+++ b/modules/github/setup.sh
@@ -2,8 +2,8 @@
 #
 # modules/github/setup.sh — Configure GitHub SSH key & bootstrap local repo
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]
 #

--- a/modules/github/test.sh
+++ b/modules/github/test.sh
@@ -2,8 +2,8 @@
 #
 # modules/github/test.sh — Verify GitHub SSH key & repo bootstrap
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -2,8 +2,8 @@
 #
 # modules/obsidian-git-client/test.sh — Verify client-side Obsidian Git sync
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # modules/obsidian-git-host/setup.sh — Git-backed Obsidian vault setup
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh setup.sh [--debug[=FILE]] [-h]
 #

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -2,8 +2,8 @@
 #
 # modules/obsidian-git-host/test.sh — Verify Obsidian vault sync configuration
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh test.sh [--log[=FILE]] [--debug[=FILE]] [-h]
 #

--- a/test-all.sh
+++ b/test-all.sh
@@ -2,8 +2,8 @@
 #
 # test-all.sh — Run tests for specified modules, enabled_modules.conf, or all modules
 # Author: deadhedd
-# Version: 1.0.2
-# Updated: 2025-08-22
+# Version: 1.0.3
+# Updated: 2025-08-24
 #
 # Usage: sh test-all.sh [--log[=FILE]] [--debug[=FILE]] [-h] [module1 module2 ...]
 #


### PR DESCRIPTION
## Summary
- Bump toolkit to version 1.0.3
- Update script headers and docs with today's date
- Keep changelog at last released version

## Testing
- `shellcheck logs/logging.sh install-modules.sh test-all.sh modules/base-system/setup.sh modules/base-system/test.sh config/load-secrets.sh modules/obsidian-git-host/setup.sh modules/obsidian-git-host/test.sh modules/obsidian-git-client/test.sh modules/github/setup.sh modules/github/test.sh` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository 403 errors)*
- `sh test-all.sh >/tmp/test.log && tail -n 20 /tmp/test.log`
- `tail -n 20 logs/test-all-20250824_175957.log` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab51c7297c8327b371793d2ede486b