### PR TITLE
docs: document obsidian git client options

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -79,6 +79,19 @@ VAULT=vault
 # Workstation vault directory name (relative to user's Documents/ or your script’s convention)
 CLIENT_VAULT=vault
 
+# Client setup options for modules/obsidian-git-client/setup.sh
+CLIENT_OWNER=admin                       # Local user that owns the vault
+CLIENT_REMOTE_URL=git@host:/path/to/vault.git  # Git remote URL
+CLIENT_BRANCH=main                       # Branch for initial commit
+CLIENT_SSH_HOST=                         # Optional override of SSH host
+CLIENT_SSH_PORT=22                       # SSH port if not 22
+CLIENT_ACCEPT_HOSTKEY=1                  # Set to 0 to skip known_hosts pinning
+CLIENT_SSH_KEY_PATH=                     # Optional custom SSH key path
+CLIENT_SSH_GENERATE=0                    # 1 to generate key if missing
+CLIENT_SSH_COPY_ID=0                     # 1 to copy key to remote
+CLIENT_PUSH_INITIAL=0                    # 1 to push initial commit if repo empty
+CLIENT_INITIAL_SYNC=none                 # none | remote-wins | local-wins | merge
+
 #=============================================================================
 # Module: GitHub (example outbound service)
 #=============================================================================

--- a/modules/obsidian-git-client/README.md
+++ b/modules/obsidian-git-client/README.md
@@ -18,9 +18,28 @@ Checks that a workstation can pull and push an Obsidian vault over SSH.
 | `GIT_SERVER` | Hostname or IP of the git server |
 
 ## Setup
-1. Copy `config/secrets.env.example` to `config/secrets.env` and edit the values.
-2. Start `ssh-agent` and add your private key.
-3. Clone the remote vault to `$HOME/$CLIENT_VAULT`.
+Run the setup script with the required options:
+
+```sh
+cd modules/obsidian-git-client
+sudo bash setup.sh --vault /path/to/Vault --owner USER --remote-url git@server:/path/to/vault.git [options]
+```
+
+### Options
+| Option | Description | Default |
+| --- | --- | --- |
+| `--vault PATH` | Vault directory (created if missing) | required |
+| `--owner USER` | Local user that owns the vault | required |
+| `--remote-url URL` | Git remote for the vault | required |
+| `--branch NAME` | Branch name to use if initializing | `main` |
+| `--ssh-host HOST` | SSH host for known_hosts | derived from remote |
+| `--ssh-port PORT` | SSH port | `22` |
+| `--no-accept-hostkey` | Skip ssh-keyscan/known_hosts pinning | host key pinned |
+| `--ssh-key-path PATH` | SSH private key path | `/home/<owner>/.ssh/id_ed25519` |
+| `--ssh-generate` | Generate key at the path if missing | off |
+| `--ssh-copy-id` | Copy the public key to the remote | off |
+| `--push-initial` | Seed a first commit and push if repo is empty | off |
+| `--initial-sync MODE` | First sync policy: `remote-wins`, `local-wins`, `merge`, or `none` | `none` |
 
 ## Testing
 ```sh


### PR DESCRIPTION
## Summary
- document obsidian git client setup.sh command-line options
- add example variables for obsidian git client module

## Testing
- `sh test-all.sh` *(fails: stat cannot read file system information for '/root/.ssh/id_ed25519', module tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9329c28c8327b19dd78c1fba92fd