### PR TITLE
Use LOCAL_VAULT for Obsidian Git plugin path in tests

### DIFF
--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -118,9 +118,9 @@ run_tests() {
   echo "1..10"
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): verifying Obsidian plugin installation" >&2
 
-  run_test "[ -d \"$HOME/.obsidian/plugins/obsidian-git\" ]" \
+  run_test "[ -d \"${LOCAL_VAULT}/.obsidian/plugins/obsidian-git\" ]" \
            "obsidian-git plugin directory exists" \
-           "ls -ld \"$HOME/.obsidian/plugins/obsidian-git\""
+           "ls -ld \"${LOCAL_VAULT}/.obsidian/plugins/obsidian-git\""
   run_test "grep -q 'obsidian-git' \"${LOCAL_VAULT}/.obsidian/plugins.json\"" \
            "obsidian-git listed in vault/.obsidian/plugins.json" \
            "grep 'obsidian-git' \"${LOCAL_VAULT}/.obsidian/plugins.json\""


### PR DESCRIPTION
## Summary
- ensure obsidian-git-client test checks plugin under LOCAL_VAULT instead of `$HOME`

## Testing
- `shellcheck modules/obsidian-git-client/test.sh` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*
- `sh modules/obsidian-git-client/test.sh` *(fails: secrets env not configured)*
- `sh test-all.sh obsidian-git-client` *(fails: missing environment and repository)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1b349388327a8a25455c0aa03fb