### PR TITLE
obsidian-git-client: check community plugin list

### DIFF
--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -121,9 +121,9 @@ run_tests() {
   run_test "[ -d \"$HOME/.obsidian/plugins/obsidian-git\" ]" \
            "obsidian-git plugin directory exists" \
            "ls -ld \"$HOME/.obsidian/plugins/obsidian-git\""
-  run_test "grep -q 'obsidian-git' \"${LOCAL_VAULT}/.obsidian/plugins.json\"" \
-           "obsidian-git listed in vault/.obsidian/plugins.json" \
-           "grep 'obsidian-git' \"${LOCAL_VAULT}/.obsidian/plugins.json\""
+  run_test "grep -q 'obsidian-git' \"${LOCAL_VAULT}/.obsidian/community-plugins.json\"" \
+           "obsidian-git listed in vault/.obsidian/community-plugins.json" \
+           "grep 'obsidian-git' \"${LOCAL_VAULT}/.obsidian/community-plugins.json\""
 
   [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): verifying auto-sync settings" >&2
 


### PR DESCRIPTION
## Summary
- verify obsidian-git plugin via community-plugins.json instead of plugins.json

## Testing
- `shellcheck modules/obsidian-git-client/test.sh` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `sh modules/obsidian-git-client/test.sh` *(fails: missing vault configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1c617908327b685373c4439acf0