### PR TITLE
obsidian-git-client: support custom vault path

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -76,6 +76,8 @@ VAULT=vault
 #=============================================================================
 # Module: Obsidian Git Client
 #=============================================================================
+# Absolute path to workstation vault (optional; overrides CLIENT_VAULT)
+CLIENT_VAULT_PATH=/home/admin/vault
 # Workstation vault directory name (relative to user's Documents/ or your script’s convention)
 CLIENT_VAULT=vault
 

--- a/modules/obsidian-git-client/README.md
+++ b/modules/obsidian-git-client/README.md
@@ -6,7 +6,7 @@ Checks that a workstation can pull and push an Obsidian vault over SSH.
 ## Prerequisites
 - Client with Git, ssh-agent and access to the remote server
 - `config/secrets.env` filled with connection details
-- Vault repository cloned locally at `$HOME/$CLIENT_VAULT`
+- Vault repository cloned locally at `$CLIENT_VAULT_PATH` (defaults to `/home/$CLIENT_OWNER/$CLIENT_VAULT`)
 
 ## Key variables
 | Variable | Description |
@@ -14,7 +14,8 @@ Checks that a workstation can pull and push an Obsidian vault over SSH.
 | `GIT_USER` | Remote git service account |
 | `OBS_USER` | Remote Obsidian account |
 | `VAULT` | Vault/repository name |
-| `CLIENT_VAULT` | Local vault directory name |
+| `CLIENT_VAULT_PATH` | Local vault directory path (optional) |
+| `CLIENT_VAULT` | Local vault directory name (used if `CLIENT_VAULT_PATH` unset) |
 | `GIT_SERVER` | Hostname or IP of the git server |
 
 ## Setup
@@ -31,7 +32,7 @@ still override any of these settings:
 ### Options
 | Option | Description | Default |
 | --- | --- | --- |
-| `--vault PATH` | Vault directory (created if missing) | `/home/$CLIENT_OWNER/$CLIENT_VAULT` |
+| `--vault PATH` | Vault directory (created if missing) | `$CLIENT_VAULT_PATH` or `/home/$CLIENT_OWNER/$CLIENT_VAULT` |
 | `--owner USER` | Local user that owns the vault | `$CLIENT_OWNER` |
 | `--remote-url URL` | Git remote for the vault | `$CLIENT_REMOTE_URL` |
 | `--branch NAME` | Branch name to use if initializing | `$CLIENT_BRANCH` or `main` |

--- a/modules/obsidian-git-client/setup.sh
+++ b/modules/obsidian-git-client/setup.sh
@@ -71,11 +71,14 @@ start_logging_if_debug "setup-$module_name" "$@"
 . "$PROJECT_ROOT/config/load-secrets.sh" "Obsidian Git Host"
 . "$PROJECT_ROOT/config/load-secrets.sh" "Obsidian Git Client"
 . "$PROJECT_ROOT/config/load-secrets.sh" "SSH"
-: "${CLIENT_VAULT:?CLIENT_VAULT must be set in secrets}"
 : "${CLIENT_OWNER:?CLIENT_OWNER must be set in secrets}"
 : "${CLIENT_REMOTE_URL:?CLIENT_REMOTE_URL must be set in secrets}"
-
-VAULT_PATH="/home/$CLIENT_OWNER/$CLIENT_VAULT"
+if [ -n "${CLIENT_VAULT_PATH:-}" ]; then
+  VAULT_PATH="$CLIENT_VAULT_PATH"
+else
+  : "${CLIENT_VAULT:?CLIENT_VAULT must be set in secrets}"
+  VAULT_PATH="/home/$CLIENT_OWNER/$CLIENT_VAULT"
+fi
 OWNER_USER="$CLIENT_OWNER"
 REMOTE_URL="$CLIENT_REMOTE_URL"
 BRANCH="${CLIENT_BRANCH:-main}"

--- a/modules/obsidian-git-client/test.sh
+++ b/modules/obsidian-git-client/test.sh
@@ -68,8 +68,11 @@ start_logging "$SCRIPT_PATH" "$@"
 . "$PROJECT_ROOT/config/load-secrets.sh" "Base System"
 . "$PROJECT_ROOT/config/load-secrets.sh" "Obsidian Git Host"
 . "$PROJECT_ROOT/config/load-secrets.sh" "Obsidian Git Client"
-
-LOCAL_VAULT="$HOME/${CLIENT_VAULT}"
+if [ -n "${CLIENT_VAULT_PATH:-}" ]; then
+  LOCAL_VAULT="$CLIENT_VAULT_PATH"
+else
+  LOCAL_VAULT="$HOME/${CLIENT_VAULT:?CLIENT_VAULT must be set in secrets}"
+fi
 SSH_KEY_FILE="${CLIENT_SSH_KEY_PATH:-$HOME/.ssh/id_ed25519}"
 SSH_KEY_BASENAME="$(basename "$SSH_KEY_FILE")"
 


### PR DESCRIPTION
## Summary
- allow specifying an absolute vault path via `CLIENT_VAULT_PATH`
- honor `CLIENT_VAULT_PATH` in setup and test scripts
- document vault path option in secrets example and module README

## Testing
- `shellcheck modules/obsidian-git-client/setup.sh` *(fails: command not found)*
- `shellcheck modules/obsidian-git-client/test.sh` *(fails: command not found)*
- `sh modules/obsidian-git-client/test.sh` *(fails: Created 'config/secrets.env' from example. Please edit it and re-run.)*


------
https://chatgpt.com/codex/tasks/task_e_68af239ccda88327a51d9f50c08a2429