### PR TITLE
feat: safely register vault via optional launch

### DIFF
--- a/config/secrets.env.example
+++ b/config/secrets.env.example
@@ -93,6 +93,7 @@ CLIENT_SSH_GENERATE=0                    # 1 to generate key if missing
 CLIENT_SSH_COPY_ID=0                     # 1 to copy key to remote
 CLIENT_PUSH_INITIAL=0                    # 1 to push initial commit if repo empty
 CLIENT_INITIAL_SYNC=none                 # none | remote-wins | local-wins | merge
+CLIENT_LAUNCH=1                          # 1 to launch Obsidian once; 0 to skip
 
 #=============================================================================
 # Module: GitHub


### PR DESCRIPTION
## Summary
- avoid direct edits to Obsidian config by removing register_vault_with_obsidian
- add --launch/--no-launch options to control one-time Obsidian CLI startup
- document new flag and default launch in secrets example

## Testing
- ⚠️ `shellcheck modules/obsidian-git-client/setup.sh` *(command not found; apt update failed)*
- ⚠️ `sh modules/obsidian-git-client/test.sh` *(Created 'config/secrets.env' from example. Please edit it and re-run.)*


------
https://chatgpt.com/codex/tasks/task_e_68af3d19403483278199cf1e4af0cc1c