### PR TITLE
docs: add v1.1.0 entry for obsidian git client module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) principles.
 
 ---
+## v1.1.0 – TBD
+
+### Added
+
+* **Obsidian Git Client Module**:
+  * Initial implementation enabling workstations to pull and push Obsidian vaults over SSH.
+
 ## v1.0.2 – 2025-08-22
 
 ### Changed


### PR DESCRIPTION
## Summary
- document obsidian git client module in changelog for v1.1.0

## Testing
- `sh test-all.sh` *(fails: missing known_hosts and repo clone; environment not set up)*

------
https://chatgpt.com/codex/tasks/task_e_68b051800330832786db4e9afb7b8cc4