### PR TITLE
obsidian-git-host: add post-commit auto push hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file following [K
 
 * **Obsidian Git Client Module**:
   * Initial implementation enabling workstations to pull and push Obsidian vaults over SSH.
+* **Obsidian Git Host Module**:
+  * Automatically pushes commits from the working copy using a `post-commit` hook.
 
 ## v1.0.2 – 2025-08-22
 

--- a/modules/obsidian-git-host/README.md
+++ b/modules/obsidian-git-host/README.md
@@ -1,7 +1,7 @@
 # obsidian-git-host
 
 ## Purpose
-Creates users and a shared bare Git repository so multiple accounts can sync an Obsidian vault. Service accounts have SSH access restricted to `git-shell`.
+Creates users and a shared bare Git repository so multiple accounts can sync an Obsidian vault. Service accounts have SSH access restricted to `git-shell`. The working copy includes a `post-commit` hook that pushes updates automatically.
 
 ## Prerequisites
 - Run as root on OpenBSD 7.4+

--- a/modules/obsidian-git-host/setup.sh
+++ b/modules/obsidian-git-host/setup.sh
@@ -461,7 +461,20 @@ chown -R "${OBS_USER}:${OBS_USER}" "$WORK_DIR"
       commit --allow-empty -m 'initial commit'
 
 ##############################################################################
-# 12) Final perms on bare repo
+# 12) Post-commit hook for auto-push
+##############################################################################
+
+HOOK_PC="$WORK_DIR/.git/hooks/post-commit"
+cat > "$HOOK_PC" <<'EOF'
+#!/bin/sh
+git push origin HEAD
+exit 0
+EOF
+chown "$OBS_USER:$OBS_USER" "$HOOK_PC"
+chmod +x "$HOOK_PC"
+
+##############################################################################
+# 13) Final perms on bare repo
 ##############################################################################
 
 # Idempotency: rollback handling and dry-run mode example
@@ -478,7 +491,7 @@ chmod -R g+rwX "$BARE_REPO"
 find "$BARE_REPO" -type d -exec chmod g+s {} +
 
 ##############################################################################
-# 13) History settings (.profile)
+# 14) History settings (.profile)
 ##############################################################################
 
 for u in "$OBS_USER" "$GIT_USER"; do

--- a/modules/obsidian-git-host/test.sh
+++ b/modules/obsidian-git-host/test.sh
@@ -287,7 +287,18 @@ check_entry() {
            "initial commit present" \
            "su - ${OBS_USER} -c \"git -C ${OBS_HOME}/vaults/${VAULT} log -1 --pretty=%B\""
 
-  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 13 final perms on bare repo" >&2
+  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 13 post-commit hook" >&2
+
+  run_test "[ -x ${OBS_HOME}/vaults/${VAULT}/.git/hooks/post-commit ]"         "post-commit hook executable" \
+           "ls -l ${OBS_HOME}/vaults/${VAULT}/.git/hooks/post-commit"
+  run_test "grep -q '^#!/bin/sh\$' ${OBS_HOME}/vaults/${VAULT}/.git/hooks/post-commit" \
+           "post-commit hook shebang correct" \
+           "head -n 1 ${OBS_HOME}/vaults/${VAULT}/.git/hooks/post-commit"
+  run_test "grep -q '^git push origin HEAD\$' ${OBS_HOME}/vaults/${VAULT}/.git/hooks/post-commit" \
+           "post-commit hook push command" \
+           "tail -n +2 ${OBS_HOME}/vaults/${VAULT}/.git/hooks/post-commit"
+
+  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 14 final perms on bare repo" >&2
 
   run_test "stat -f '%Su:%Sg' ${BARE_REPO} | grep -q '^${GIT_USER}:vault\$'"   "ownership of '${BARE_REPO}' is '${GIT_USER}:vault'" \
            "stat -f '%Su:%Sg' ${BARE_REPO}"
@@ -309,7 +320,7 @@ check_entry() {
   run_test "! find ${BARE_REPO} -type d -not -perm -g+s -print | grep -q ."  "all directories under '${BARE_REPO}' have the setgid bit set" \
            "find ${BARE_REPO} -type d -not -perm -g+s -print | head -n 20"
 
-  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 14 history settings" >&2
+  [ "$DEBUG_MODE" -eq 1 ] && echo "DEBUG(run_tests): Section 15 history settings" >&2
 
   run_test "grep -q '^export HISTFILE=/home/${OBS_USER}/.ksh_history\$' /home/${OBS_USER}/.profile" \
            "HISTFILE export in ${OBS_USER} .profile" \


### PR DESCRIPTION
## Summary
- push commits automatically from working copy via post-commit hook
- check for the new hook in obsidian git host tests
- document automatic pushing in the Obsidian Git Host README and changelog

## Testing
- `shellcheck modules/obsidian-git-host/setup.sh modules/obsidian-git-host/test.sh` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors)*
- `sh modules/obsidian-git-host/test.sh` *(fails: OBS_USER must be set in secrets)*

------
https://chatgpt.com/codex/tasks/task_e_68b19c1642448327ba59597c1c3e5e9c